### PR TITLE
Feat/scion tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,4 +21,7 @@
                                      org.clojure/clojure         {:mvn/version "1.10.3"}
                                      org.clojure/clojurescript   {:mvn/version "1.10.891"}
                                      binaryage/devtools          {:mvn/version "1.0.4"}
-                                     org.clojure/tools.namespace {:mvn/version "1.1.0"}}}}}
+                                     org.clojure/tools.namespace {:mvn/version "1.1.0"}
+                                     org.clojure/data.json       {:mvn/version "2.4.0"}
+                                     zprint/zprint               {:mvn/version "1.2.2"}
+                                     camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.2"}}}}}

--- a/src/dev/scion_tests_converter.clj
+++ b/src/dev/scion_tests_converter.clj
@@ -1,0 +1,101 @@
+(ns scion-tests-converter
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [scxml-converter :refer [translate-scxml]]
+            [clojure.data.json :as json]
+            [cljfmt.main :as cljfmt]
+            [cljfmt.core :as cljfmt-core]
+            [camel-snake-kebab.core :as csk]
+            [zprint.core :as zp]))
+
+(defn make-assertions [states]
+  (let [assertions (mapcat
+                     (fn [state]
+                       [`(~'testing/in? ~'env ~(keyword state)) '=> 'true])
+                     states)]
+    `(~'assertions
+       ~@assertions)))
+
+(defn make-event-and-assertions [{:keys [event nextConfiguration] :as payload}]
+  [`(~'testing/run-events! ~'env ~(-> event :name keyword))
+   (make-assertions nextConfiguration)])
+
+(defn statechart-initial->maybe-keyword [props]
+  (if (:initial props)
+    (update props :initial keyword)
+    props))
+
+(defn make-test-code [test-name chart test]
+  (let [[_ chart-props & chart-body] chart
+        statechart-props (-> chart-props
+                           (select-keys [:initial])
+                           statechart-initial->maybe-keyword)
+        test-body (into [(make-assertions (:initialConfiguration test))]
+                     (mapcat make-event-and-assertions (:events test)))
+        template  `(~'specification ~test-name
+                     (~'let [~'chart (~'chart/statechart ~statechart-props
+                                   ~@chart-body)
+                           ~'env   (~'testing/new-testing-env {:statechart ~'chart} {})]
+
+                       (~'testing/start! ~'env)
+
+                       ~@test-body))]
+    template))
+
+(defn port-test [[test-name {:keys [scxml json] :as v}]]
+  (let [translated-scxml (translate-scxml scxml {:ns-alias nil})
+        test (json/read-str json :key-fn keyword)]
+    (println json)
+    (make-test-code test-name translated-scxml test)))
+
+(defn file-header [filename]
+  (let [file-ns (symbol (str "com.fulcrologic.statecharts.algorithms.v20150901."
+                          (csk/->kebab-case filename) "-spec"))]
+    `(~'ns ~file-ns
+       ~'(:require
+           [com.fulcrologic.statecharts.elements
+            :refer [state
+                    initial
+                    parallel
+                    final
+                    transition
+                    raise
+                    on-entry
+                    on-exit
+                    data-model
+                    assign
+                    script
+                    history
+                    log]]
+           [com.fulcrologic.statecharts :as sc]
+           [com.fulcrologic.statecharts.chart :as chart]
+           [com.fulcrologic.statecharts.testing :as testing]
+           [com.fulcrologic.statecharts.data-model.operations :as ops]
+           [fulcro-spec.core :refer [specification assertions =>]]))))
+
+(defn port-tests [root-dir dir]
+  (let [directory (io/file (str root-dir dir))
+        files (file-seq directory)
+        contents  (->> (reduce
+                         (fn [acc file]
+                           (if (.isDirectory file)
+                             acc
+                             (let [filename  (last (str/split (.getName file) #"/"))
+                                   test-name (first (str/split filename #"\."))
+                                   ext       (last (str/split filename #"\."))]
+                               (assoc-in acc [test-name (keyword ext)] (slurp file)))))
+                         {}
+                         files)
+                    (sort-by (fn [[k _]] k))
+                    (map port-test))
+        filename  (str (System/getProperty "user.dir") "/out/converted.clj")
+        contents  (str/join "\n\n" (map pr-str (into [(file-header dir)] contents)))]
+
+    (io/make-parents filename)
+
+    (spit filename (zp/zprint-file-str contents "" {:width 80}))))
+
+(comment
+  (port-tests  "/Users/retro/Projects/scion-test-framework/test/" "parallel+interrupt")
+  ;;
+  )

--- a/src/dev/scxml_converter.clj
+++ b/src/dev/scxml_converter.clj
@@ -4,14 +4,26 @@
     [clojure.string :as str]
     [hickory.core :as hc]))
 
-(def coercions {:id     keyword
-                :event  keyword
-                :name   keyword
+(def coercions {:id       keyword
+                :event    keyword
+                :name     keyword
+                :initial  keyword
+                :type     keyword
+                :location keyword
                 :target (fn [t]
                           (let [targets (str/split t #" ")]
                             (if (= 1 (count targets))
                               (keyword (first targets))
                               (mapv keyword targets))))})
+
+(def tag-coercions
+  {"onentry" "on-entry"
+   "onexit" "on-exit"
+   "datamodel" "data-model"})
+
+
+(defn coerce-tag [tag]
+  (get tag-coercions tag tag))
 
 (defn element->call
   ([elem]
@@ -27,7 +39,7 @@
              (str/ends-with? elem "-->"))
            (re-matches #"^[ \n]*$" elem)))) nil
      (string? elem) (str/trim elem)
-     (vector? elem) (let [tag               (symbol (name (first elem)))
+     (vector? elem) (let [tag               (symbol (coerce-tag (name (first elem))))
                           raw-props         (second elem)
                           attrs             (reduce-kv
                                               (fn [acc k v]

--- a/src/main/com/fulcrologic/statecharts/algorithms/v20150901_impl.cljc
+++ b/src/main/com/fulcrologic/statecharts/algorithms/v20150901_impl.cljc
@@ -417,7 +417,7 @@
         (when (seq (set/intersection
                      (compute-exit-set env [t1])
                      (compute-exit-set env [t2])))
-          (if (chart/descendant? statechart (chart/source t1) (chart/source t2))
+          (if (chart/descendant? statechart (chart/source statechart t1) (chart/source statechart t2))
             (vswap! to-remove conj t2)
             (vreset! preempted? true))))
       (when (not @preempted?)

--- a/src/main/com/fulcrologic/statecharts/algorithms/v20150901_validation.cljc
+++ b/src/main/com/fulcrologic/statecharts/algorithms/v20150901_validation.cljc
@@ -20,11 +20,14 @@
       (< (count substate-ids) 2) (conj (warning ele (str "Parallel state " id " has fewer than 2 substates.")))
       (seq children) (into (mapcat #(problems chart %) children)))))
 
+
 (defmethod element-problems :state [chart {:keys [id target event cond children] :as ele}]
   (let [tids           (chart/transitions chart ele)
         transitions    (map #(chart/element chart %) tids)
         by-event       (group-by (fn [e] [(:event e) (:cond e)]) transitions)
-        event-problems (for [k (keys by-event)
+        ;; This case seems to be valid (at least it's supported in SCION), and document order should
+        ;; take care of selecting the correct transition
+        event-problems [] #_(for [k (keys by-event)
                              :when (> (count (get by-event k)) 1)]
                          (error ele (str "More than one transition in state " id
                                       " has the exact same event and condition: " (get by-event k))))]

--- a/src/main/com/fulcrologic/statecharts/testing.cljc
+++ b/src/main/com/fulcrologic/statecharts/testing.cljc
@@ -67,6 +67,15 @@
                                   (sp/update! data-model env {:ops result}))
                                 result)
       (contains? @mocks expr) (get @mocks expr)
+      (fn? expr) (let [env     (assoc env :ncalls (get @call-counts expr))
+                       data    (sp/current-data data-model env)
+                       result  (log/spy :trace "expr => " (expr env data))
+                       update? (vector? result)]
+                   (log/info "Running expr")
+                   (when update?
+                     (log/trace "trying vector result as a data model update" result)
+                     (sp/update! data-model env {:ops result}))
+                   result)
       :else expr)))
 
 (defn new-mock-execution

--- a/src/main/com/fulcrologic/statecharts/testing.cljc
+++ b/src/main/com/fulcrologic/statecharts/testing.cljc
@@ -66,7 +66,8 @@
                                   (log/trace "trying vector result as a data model update" result)
                                   (sp/update! data-model env {:ops result}))
                                 result)
-      (contains? @mocks expr) (get @mocks expr))))
+      (contains? @mocks expr) (get @mocks expr)
+      :else expr)))
 
 (defn new-mock-execution
   "Create a mock exection model. Records the expressions seen. If the expression has an

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/action_send_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/action_send_spec.cljc
@@ -1,0 +1,242 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.action-send-spec
+  (:require
+    [com.fulcrologic.statecharts.elements
+     :refer [state
+             initial
+             parallel
+             final
+             transition
+             raise
+             on-entry
+             on-exit]]
+    [com.fulcrologic.statecharts :as sc]
+    [com.fulcrologic.statecharts.chart :as chart]
+    [com.fulcrologic.statecharts.testing :as testing]
+    [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification "send1"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b :event :t}
+                    (raise {:event :s})))
+                (state {:id :b}
+                  (transition {:target :c :event :s}))
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :c) => true)))
+
+(specification "send2"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (on-exit {}
+                    (raise {:event :s}))
+                  (transition {:target :b :event :t}))
+                (state {:id :b}
+                  (transition {:target :c :event :s}))
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :c) => true)))
+
+
+(specification "send3"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b :event :t}))
+                (state {:id :b}
+                  (on-entry {}
+                    (raise {:event :s}))
+                  (transition {:target :c :event :s}))
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :c) => true)))
+
+(specification "send4"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b :event :t}))
+                (state {:id :b}
+                  (on-entry {}
+                    (raise {:event :s}))
+                  (transition {:target :c :event :s})
+                  (transition {:target :f1}))
+                (state {:id :c}
+                  (transition {:target :f2 :event :s})
+                  (transition {:target :d}))
+                (state {:id :f1})
+                (state {:id :d})
+                (state {:id :f2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :f1) => true)))
+
+(specification "send4b"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b :event :t}))
+                (state {:id :b}
+                  (on-entry {}
+                    (raise {:event :s}))
+                  (transition {:target :c :event :s}))
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :c) => true)))
+
+(specification "send7"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b :event :t}
+                    (raise {:event :s})))
+                (state {:id :b :initial :b1}
+                  (state {:id :b1}
+                    (transition {:event :s :target :b2})
+                    (transition {:target :b3}))
+                  (state {:id :b2})
+                  (state {:id :b3})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :b3) => true)))
+
+(specification "send7b"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b :event :t}
+                    (raise {:event :s})))
+                (state {:id :b :initial :b1}
+                  (state {:id :b1}
+                    (transition {:event :s :target :b2}))
+                  (state {:id :b2})
+                  (state {:id :b3})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :b2) => true)))
+
+
+(specification "send8"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b1 :event :t}
+                    (raise {:event :s})))
+                (state {:id :b :initial :b1}
+                  (state {:id :b1}
+                    (transition {:event :s :target :b2})
+                    (transition {:target :b3}))
+                  (state {:id :b2})
+                  (state {:id :b3})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :b3) => true)))
+
+(specification "send8b"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b1 :event :t}
+                    (raise {:event :s})))
+                (state {:id :b :initial :b1}
+                  (state {:id :b1}
+                    (transition {:event :s :target :b2}))
+                  (state {:id :b2})
+                  (state {:id :b3})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :b2) => true)))
+
+(specification "send9"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b :event :t}
+                    (raise {:event :s})))
+                (state {:id :b}
+                  (initial {}
+                    (transition {:target :b1}))
+                  (state {:id :b1}
+                    (transition {:event :s :target :b2})
+                    (transition {:target :b3}))
+                  (state {:id :b2})
+                  (state {:id :b3})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :b3) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign.cljc
@@ -1,0 +1,67 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.assign
+  (:require
+    [com.fulcrologic.statecharts.elements
+     :refer [state
+             initial
+             parallel
+             final
+             transition
+             raise
+             on-entry
+             on-exit
+             data-model
+             assign
+             script]]
+    [com.fulcrologic.statecharts :as sc]
+    [com.fulcrologic.statecharts.chart :as chart]
+    [com.fulcrologic.statecharts.testing :as testing]
+    [com.fulcrologic.statecharts.data-model.operations :as ops]
+    [fulcro-spec.core :refer [specification assertions =>]]))
+
+;; Not sure if this test makes sense?
+#_(specification "assign_invalid"
+  (let [chart (chart/statechart {}
+                (data-model
+                  {:id :o1})
+                (state {:id :uber}
+                  (transition {:event :error.execution :target :pass})
+                  (transition {:event :* :target :fail})
+
+                  (state {:id :s1}
+                    (on-entry {}
+                      (assign {:location :o1 :expr (fn [_ _] (throw (ex-info "Failing" {})))}))))
+
+                (final {:id :pass})
+                (final {:id :fail}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :pass) => true)))
+
+(specification "assign_map_literal" :focus
+  (let [chart (chart/statechart {}
+                (data-model
+                  {:id :o1})
+                (state {:id :uber}
+                  (transition {:event :* :target :fail})
+
+                  (state {:id :s1}
+                    (transition {:event :pass :target :pass})
+                    (on-entry {}
+                      (assign {:location :o1 :expr {:p1 :v1 :p2 :v2}}))))
+
+                (final {:id :pass})
+                (final {:id :fail}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :s1) => true)
+
+    (testing/run-events! env :pass)
+
+    (assertions
+      (testing/in? env :pass) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign_current_small_step.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign_current_small_step.cljc
@@ -1,0 +1,194 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.assign-current-small-step
+  (:require
+    [com.fulcrologic.statecharts.elements
+     :refer [state
+             initial
+             parallel
+             final
+             transition
+             raise
+             on-entry
+             on-exit
+             data-model
+             assign
+             script]]
+    [com.fulcrologic.statecharts :as sc]
+    [com.fulcrologic.statecharts.chart :as chart]
+    [com.fulcrologic.statecharts.testing :as testing]
+    [com.fulcrologic.statecharts.data-model.operations :as ops]
+    [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification "test0"
+  (let [chart (chart/statechart {}
+                (data-model
+                  {:id :x})
+                (state {:id :a}
+                  (on-entry {}
+                    (assign {:location :x :expr -1})
+                    (assign {:location :x :expr 99}))
+                  (transition {:event :t
+                               :target :b
+                               :cond (fn [_ {:keys [x]}] (println "AA") (= x 99))}))
+                (state {:id :b}
+                  (on-entry {}
+                    (script {:expr (fn script* [env {:keys [x]}]
+                                     [(ops/assign [:ROOT :x] (* 2 x))])}))
+                  (transition {:target :c
+                               :cond (fn [_ {:keys [x]}] (println "X" x) (= 200 x))})
+                  (transition {:target :f}))
+                (state {:id :c})
+                (state {:id :f}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :c) => true)))
+
+(specification "test1"
+  (let [chart (chart/statechart {}
+                (data-model
+                  {:id :i})
+                (state {:id :a}
+                  (transition {:target :b :event :t}
+                    (assign {:location :i :expr 0})))
+                (state {:id :b}
+                  (transition {:target :b
+                               :cond (fn [_ {:keys [i]}] (< i 100))}
+                    (assign {:location :i :expr (fn [_ {:keys [i]}] (inc i))}))
+                  (transition {:target :c :cond (fn [_ {:keys [i]}] (= i 100))}))
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :c) => true)))
+
+(specification "test2"
+  (let [chart (chart/statechart {}
+                (data-model
+                  {:id :i})
+                (state {:id :a}
+                  (transition {:target :b :event :t}
+                    (assign {:location :i :expr 0})))
+                (state {:id :A}
+                  (state {:id :b}
+                    (transition {:target :c
+                                 :cond (fn [_ {:keys [i]}] (< i 100))}
+                      (assign {:location :i :expr (fn [_ {:keys [i]}] (inc i))})))
+                  (state {:id :c}
+                    (transition {:target :b
+                                 :cond (fn [_ {:keys [i]}] (< i 100))}
+                      (assign {:location :i :expr (fn [_ {:keys [i]}] (inc i))})))
+                  (transition {:target :d :cond (fn [_ {:keys [i]}] (= i 100))}
+                    (assign {:location :i :expr (fn [_ {:keys [i]}] (* 2 i))})))
+                (state {:id :d}
+                  (transition {:target :e :cond (fn [_ {:keys [i]}] (= i 200))})
+                  (transition {:target :f}))
+                (state {:id :e})
+                (state {:id :f}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :e) => true)))
+
+(specification "test3"
+  (let [chart (chart/statechart {}
+                (data-model
+                  {:id :i})
+                (state {:id :a}
+                  (transition {:target :p :event :t1}
+                    (assign {:location :i :expr 0})))
+                (parallel {:id :p}
+                  (state {:id :b :initial :b1}
+                    (state {:id :b1}
+                      (transition {:event :t2 :target :b2}
+                        (assign {:location :i :expr (fn [_ {:keys [i]}] (inc i))})))
+                    (state {:id :b2}))
+                  (state {:id :c :initial :c1}
+                    (state {:id :c1}
+                      (transition {:event :t2 :target :c2}
+                        (assign {:location :i :expr (fn [_ {:keys [i]}] (dec i))})))
+                    (state {:id :c2}))
+
+                  (transition {:event :t3 :target :d :cond (fn [_ {:keys [i]}] (= i 0))})
+                  (transition {:event :t3 :target :f}))
+                (state {:id :d})
+                (state {:id :f}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t1)
+
+    (assertions
+      (testing/in? env :b1) => true
+      (testing/in? env :c1) => true)
+
+    (testing/run-events! env :t2)
+
+    (assertions
+      (testing/in? env :b2) => true
+      (testing/in? env :c2) => true)
+
+    (testing/run-events! env :t3)
+
+    (assertions
+      (testing/in? env :d) => true)))
+
+(specification "test4"
+  (let [chart (chart/statechart {}
+                (data-model
+                  {:id :x})
+                (state {:id :a}
+                  (on-entry {}
+                    (assign {:location :x :expr 2}))
+                  (transition {:event :t :target :b1}))
+
+                (state {:id :b}
+                  (on-entry {}
+                    (assign {:location :x :expr (fn [_ {:keys [x]}] (* x 3))}))
+                  (state {:id :b1}
+                    (on-entry {}
+                      (assign {:location :x :expr (fn [_ {:keys [x]}] (* x 5))})))
+                  (state {:id :b2}
+                    (on-entry {}
+                      (assign {:location :x :expr (fn [_ {:keys [x]}] (* x 7))})))
+
+                  (transition {:target :c :cond (fn [_ {:keys [x]}] (= x 30))})
+                  (transition {:target :f}))
+
+                (state {:id :c})
+                (state {:id :f}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :c) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign_current_small_step_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign_current_small_step_spec.cljc
@@ -1,4 +1,4 @@
-(ns com.fulcrologic.statecharts.algorithms.v20150901.assign-current-small-step
+(ns com.fulcrologic.statecharts.algorithms.v20150901.assign-current-small-step-spec
   (:require
     [com.fulcrologic.statecharts.elements
      :refer [state
@@ -21,20 +21,20 @@
 (specification "test0"
   (let [chart (chart/statechart {}
                 (data-model
-                  {:id :x})
+                  {:expr {:x nil}})
                 (state {:id :a}
                   (on-entry {}
                     (assign {:location :x :expr -1})
                     (assign {:location :x :expr 99}))
                   (transition {:event :t
                                :target :b
-                               :cond (fn [_ {:keys [x]}] (println "AA") (= x 99))}))
+                               :cond (fn [_ {:keys [x]}] (= x 99))}))
                 (state {:id :b}
                   (on-entry {}
                     (script {:expr (fn script* [env {:keys [x]}]
                                      [(ops/assign [:ROOT :x] (* 2 x))])}))
                   (transition {:target :c
-                               :cond (fn [_ {:keys [x]}] (println "X" x) (= 200 x))})
+                               :cond (fn [_ {:keys [x]}] (= 200 x))})
                   (transition {:target :f}))
                 (state {:id :c})
                 (state {:id :f}))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign_spec_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/assign_spec_spec.cljc
@@ -1,4 +1,4 @@
-(ns com.fulcrologic.statecharts.algorithms.v20150901.assign
+(ns com.fulcrologic.statecharts.algorithms.v20150901.assign-spec-spec
   (:require
     [com.fulcrologic.statecharts.elements
      :refer [state
@@ -20,27 +20,27 @@
 
 ;; Not sure if this test makes sense?
 #_(specification "assign_invalid"
-  (let [chart (chart/statechart {}
-                (data-model
-                  {:id :o1})
-                (state {:id :uber}
-                  (transition {:event :error.execution :target :pass})
-                  (transition {:event :* :target :fail})
+    (let [chart (chart/statechart {}
+                  (data-model
+                    {:id :o1})
+                  (state {:id :uber}
+                    (transition {:event :error.execution :target :pass})
+                    (transition {:event :* :target :fail})
 
-                  (state {:id :s1}
-                    (on-entry {}
-                      (assign {:location :o1 :expr (fn [_ _] (throw (ex-info "Failing" {})))}))))
+                    (state {:id :s1}
+                      (on-entry {}
+                        (assign {:location :o1 :expr (fn [_ _] (throw (ex-info "Failing" {})))}))))
 
-                (final {:id :pass})
-                (final {:id :fail}))
-        env   (testing/new-testing-env {:statechart chart} {})]
+                  (final {:id :pass})
+                  (final {:id :fail}))
+          env   (testing/new-testing-env {:statechart chart} {})]
 
-    (testing/start! env)
+      (testing/start! env)
 
-    (assertions
-      (testing/in? env :pass) => true)))
+      (assertions
+        (testing/in? env :pass) => true)))
 
-(specification "assign_map_literal" :focus
+(specification "assign_map_literal"
   (let [chart (chart/statechart {}
                 (data-model
                   {:id :o1})

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/atom_3_basic_tests_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/atom_3_basic_tests_spec.cljc
@@ -1,0 +1,90 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.atom-3-basic-tests-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit data-model assign script log]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification "m0"
+  (let [chart (chart/statechart {}
+                (state {:id :A}
+                  (on-entry {} (log {:expr "entering A"}))
+                  (on-exit {} (log {:expr "exiting A"}))
+                  (transition {:target :B, :event :e1}
+                    (log {:expr "doing A->B transition"})))
+                (state {:id :B} (transition {:target :A, :event :e2})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :A) => true)
+    (testing/run-events! env :e1)
+    (assertions (testing/in? env :B) => true)
+    (testing/run-events! env :e2)
+    (assertions (testing/in? env :A) => true)))
+
+(specification
+  "m1"
+  (let [chart (chart/statechart
+                {}
+                (state {:id :A}
+                  (on-entry {} (log {:expr "entering state A"}))
+                  (on-exit {} (log {:expr "exiting state A"}))
+                  (transition {:target :B, :event :e1} (log {:expr "triggered by e1"})))
+                (state {:id :B} (transition {:target :A, :event :e2} (log {:expr "triggered by e2"}))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :A) => true)
+    (testing/run-events! env :e1)
+    (assertions (testing/in? env :B) => true)
+    (testing/run-events! env :e2)
+    (assertions (testing/in? env :A) => true)))
+
+(specification
+  "m2"
+  (let [chart
+            (chart/statechart
+              {}
+              (state {:id :AB}
+                (initial {} (transition {:target :A}))
+                (state {:id :A}
+                  (on-entry {} (log {:expr "entering state A"}))
+                  (on-exit {} (log {:expr "exiting state A"}))
+                  (transition {:target :B, :event :e1} (log {:expr "triggered by e1"})))
+                (state {:id :B}
+                  (transition {:target :A, :event :e2} (log {:expr "triggered by e2"})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :A) => true)
+    (testing/run-events! env :e1)
+    (assertions (testing/in? env :B) => true)
+    (testing/run-events! env :e2)
+    (assertions (testing/in? env :A) => true)))
+
+(specification
+  "m3"
+  (let [chart (chart/statechart
+                {}
+                (state {:id :AB}
+                  (initial {} (transition {:target :A}))
+                  (state {:id :A}
+                    (on-entry {} (log {:expr "entering state A"}))
+                    (on-exit {} (log {:expr "exiting state A"}))
+                    (transition {:target :B, :event :e1} (log {:expr "triggered by e1"})))
+                  (state {:id :B}
+                    (transition {:target :A, :event :e2} (log {:expr "triggered by e2"})))
+                  (transition {:target :C, :event :e1}))
+                (state {:id :C}
+                  (on-entry {} (log {:expr "entering state C"}))
+                  (on-exit {} (log {:expr "exiting state C"}))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :A) => true)
+    (testing/run-events! env :e1)
+    (assertions (testing/in? env :B) => true)
+    (testing/run-events! env :e2)
+    (assertions (testing/in? env :A) => true)
+    (testing/run-events! env :e1)
+    (assertions (testing/in? env :B) => true)
+    (testing/run-events! env :e1)
+    (assertions (testing/in? env :C) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/basic_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/basic_spec.cljc
@@ -1,0 +1,35 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.basic-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit data-model assign script]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification "basic0"
+  (let [chart (chart/statechart {:initial :a} (state {:id :a}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)))
+
+(specification "basic1"
+  (let [chart (chart/statechart {} (state {:id :a} (transition {:target :b, :event :t})) (state {:id :b}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :b) => true)))
+
+(specification "basic2"
+  (let [chart (chart/statechart {}
+                (state {:id :a} (transition {:target :b, :event :t}))
+                (state {:id :b} (transition {:target :c, :event :t2}))
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :b) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :c) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/default_initial_state_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/default_initial_state_spec.cljc
@@ -1,0 +1,33 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.default-initial-state-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification
+  "initial1"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b, :event :t}))
+                (state {:id :b}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :b) => true)))
+
+(specification
+  "initial2"
+  (let [chart (chart/statechart {:initial :a}
+                (state {:id :a}
+                  (transition {:target :b, :event :t}))
+                (state {:id :b}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :b) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/document_order_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/document_order_spec.cljc
@@ -1,0 +1,23 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.document-order-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification
+  "documentOrder0"
+  (let [chart (chart/statechart {}
+                (state {:id :a}
+                  (transition {:target :b, :event :t})
+                  (transition {:target :c, :event :t}))
+                (state {:id :b})
+                (state {:id :c}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :b) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/hierarchy_document_order_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/hierarchy_document_order_spec.cljc
@@ -1,0 +1,43 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.hierarchy-document-order-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification "test0"
+  (let [chart (chart/statechart
+                {}
+                (state {:id :a}
+                  (state {:id :a1}
+                    (transition {:target :a2, :event :t})
+                    (transition {:target :c, :event :t}))
+                  (state {:id :a2})
+                  (transition {:target :b, :event :t}))
+                (state {:id :b})
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a2) => true)))
+
+(specification "test1"
+  (let [chart (chart/statechart
+                {}
+                (state {:id :a}
+                  (state {:id :a1}
+                    (transition {:target :b, :event :t})
+                    (transition {:target :c, :event :t}))
+                  (state {:id :a2})
+                  (transition {:target :a2, :event :t}))
+                (state {:id :b})
+                (state {:id :c}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :b) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/hierarchy_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/hierarchy_spec.cljc
@@ -1,0 +1,52 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.hierarchy-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification
+  "hier0"
+  (let [chart (chart/statechart
+                {}
+                (state {:id :a}
+                  (state {:id :a1} (transition {:target :a2, :event :t}))
+                  (state {:id :a2})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a2) => true)))
+
+(specification
+  "hier1"
+  (let [chart (chart/statechart
+                {}
+                (state {:id :a}
+                  (state {:id :a1} (transition {:target :a2, :event :t}))
+                  (state {:id :a2})
+                  (transition {:target :b, :event :t}))
+                (state {:id :b}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a2) => true)))
+
+(specification
+  "hier2"
+  (let [chart (chart/statechart
+                {}
+                (state {:id :a}
+                  (state {:id :a1} (transition {:target :b, :event :t}))
+                  (state {:id :a2})
+                  (transition {:target :a2, :event :t}))
+                (state {:id :b}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :b) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/history_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/history_spec.cljc
@@ -1,0 +1,339 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.history-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script history log]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification
+  "history0"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a} (transition {:target :h, :event :t1}))
+                (state {:id :b, :initial :b1}
+                  (history {:id :h} (transition {:target :b2}))
+                  (state {:id :b1})
+                  (state {:id :b2} (transition {:event :t2, :target :b3}))
+                  (state {:id :b3} (transition {:event :t3, :target :a}))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b2) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b3) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b3) => true)))
+
+(specification
+  "history1"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a} (transition {:target :h, :event :t1}))
+                (state
+                  {:id :b, :initial :b1}
+                  (history {:id :h, :type :deep} (transition {:target :b1.2}))
+                  (state
+                    {:id :b1, :initial :b1.1}
+                    (state {:id :b1.1})
+                    (state {:id :b1.2} (transition {:event :t2, :target :b1.3}))
+                    (state {:id :b1.3} (transition {:event :t3, :target :a})))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b1.2) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b1.3) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b1.3) => true)))
+
+(specification
+  "history2"
+  (let [chart
+            (chart/statechart
+              {:initial :a}
+              (state {:id :a} (transition {:target :h, :event :t1}))
+              (state
+                {:id :b, :initial :b1}
+                (history {:id :h, :type :shallow} (transition {:target :b1.2}))
+                (state
+                  {:id :b1, :initial :b1.1}
+                  (state {:id :b1.1})
+                  (state {:id :b1.2} (transition {:event :t2, :target :b1.3}))
+                  (state {:id :b1.3} (transition {:event :t3, :target :a})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b1.2) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b1.3) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b1.1) => true)))
+
+(specification
+  "history3"
+  (let [chart
+            (chart/statechart
+              {:initial :a}
+              (state {:id :a}
+                (transition {:target :p, :event :t1})
+                (transition {:target :h, :event :t4}))
+              (parallel
+                {:id :p}
+                (history {:id :h, :type :deep} (transition {:target :b}))
+                (state {:id :b, :initial :b1}
+                  (state {:id :b1} (transition {:target :b2, :event :t2}))
+                  (state {:id :b2}))
+                (state {:id :c, :initial :c1}
+                  (state {:id :c1} (transition {:target :c2, :event :t2}))
+                  (state {:id :c2}))
+                (transition {:target :a, :event :t3})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b1) => true (testing/in? env :c1) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b2) => true (testing/in? env :c2) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t4)
+    (assertions (testing/in? env :b2) => true (testing/in? env :c2) => true)))
+
+(specification
+  "history4"
+  (let [chart
+            (chart/statechart
+              {:initial :a}
+              (state {:id :a}
+                (transition {:target :p, :event :t1})
+                (transition {:target :p, :event :t6})
+                (transition {:target :hp, :event :t9}))
+              (parallel
+                {:id :p}
+                (history {:id :hp, :type :deep} (transition {:target :b}))
+                (state
+                  {:id :b, :initial :hb}
+                  (history {:id :hb, :type :deep} (transition {:target :b1}))
+                  (state
+                    {:id :b1, :initial :b1.1}
+                    (state {:id :b1.1} (transition {:target :b1.2, :event :t2}))
+                    (state {:id :b1.2} (transition {:target :b2, :event :t3})))
+                  (state {:id :b2, :initial :b2.1}
+                    (state {:id :b2.1}
+                      (transition {:target :b2.2, :event :t4}))
+                    (state {:id :b2.2}
+                      (transition {:target :a, :event :t5})
+                      (transition {:target :a, :event :t8}))))
+                (state
+                  {:id :c, :initial :hc}
+                  (history {:id :hc, :type :shallow} (transition {:target :c1}))
+                  (state
+                    {:id :c1, :initial :c1.1}
+                    (state {:id :c1.1} (transition {:target :c1.2, :event :t2}))
+                    (state {:id :c1.2} (transition {:target :c2, :event :t3})))
+                  (state {:id :c2, :initial :c2.1}
+                    (state {:id :c2.1}
+                      (transition {:target :c2.2, :event :t4})
+                      (transition {:target :c2.2, :event :t7}))
+                    (state {:id :c2.2})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b1.1) => true (testing/in? env :c1.1) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b1.2) => true (testing/in? env :c1.2) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :b2.1) => true (testing/in? env :c2.1) => true)
+    (testing/run-events! env :t4)
+    (assertions (testing/in? env :b2.2) => true (testing/in? env :c2.2) => true)
+    (testing/run-events! env :t5)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t6)
+    (assertions (testing/in? env :b2.2) => true (testing/in? env :c2.1) => true)
+    (testing/run-events! env :t7)
+    (assertions (testing/in? env :b2.2) => true (testing/in? env :c2.2) => true)
+    (testing/run-events! env :t8)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t9)
+    (assertions (testing/in? env :b2.2)
+      =>
+      true
+      (testing/in? env :c2.2)
+      =>
+      true)))
+
+(specification
+  "history4b"
+  (let [chart
+            (chart/statechart
+              {:initial :a}
+              (state {:id :a}
+                (transition {:target :p, :event :t1})
+                (transition {:target [:hb :hc], :event :t6})
+                (transition {:target :hp, :event :t9}))
+              (parallel
+                {:id :p}
+                (history {:id :hp, :type :deep} (transition {:target :b}))
+                (state
+                  {:id :b, :initial :hb}
+                  (history {:id :hb, :type :deep} (transition {:target :b1}))
+                  (state
+                    {:id :b1, :initial :b1.1}
+                    (state {:id :b1.1} (transition {:target :b1.2, :event :t2}))
+                    (state {:id :b1.2} (transition {:target :b2, :event :t3})))
+                  (state {:id :b2, :initial :b2.1}
+                    (state {:id :b2.1}
+                      (transition {:target :b2.2, :event :t4}))
+                    (state {:id :b2.2}
+                      (transition {:target :a, :event :t5})
+                      (transition {:target :a, :event :t8}))))
+                (state
+                  {:id :c, :initial :hc}
+                  (history {:id :hc, :type :shallow} (transition {:target :c1}))
+                  (state
+                    {:id :c1, :initial :c1.1}
+                    (state {:id :c1.1} (transition {:target :c1.2, :event :t2}))
+                    (state {:id :c1.2} (transition {:target :c2, :event :t3})))
+                  (state {:id :c2, :initial :c2.1}
+                    (state {:id :c2.1}
+                      (transition {:target :c2.2, :event :t4})
+                      (transition {:target :c2.2, :event :t7}))
+                    (state {:id :c2.2})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b1.1) => true (testing/in? env :c1.1) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b1.2) => true (testing/in? env :c1.2) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :b2.1) => true (testing/in? env :c2.1) => true)
+    (testing/run-events! env :t4)
+    (assertions (testing/in? env :b2.2) => true (testing/in? env :c2.2) => true)
+    (testing/run-events! env :t5)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t6)
+    (assertions (testing/in? env :b2.2) => true (testing/in? env :c2.1) => true)
+    (testing/run-events! env :t7)
+    (assertions (testing/in? env :b2.2) => true (testing/in? env :c2.2) => true)
+    (testing/run-events! env :t8)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t9)
+    (assertions (testing/in? env :b2.2)
+      =>
+      true
+      (testing/in? env :c2.2)
+      =>
+      true)))
+
+(specification
+  "history5"
+  (let [chart
+            (chart/statechart
+              {:initial :a}
+              (parallel
+                {:id :a}
+                (history {:id :ha, :type :deep} (transition {:target :b}))
+                (parallel
+                  {:id :b}
+                  (parallel
+                    {:id :c}
+                    (parallel
+                      {:id :d}
+                      (parallel
+                        {:id :e}
+                        (state
+                          {:id :i, :initial :i1}
+                          (state {:id :i1} (transition {:target :i2, :event :t1}))
+                          (state {:id :i2} (transition {:target :l, :event :t2})))
+                        (state {:id :j}))
+                      (state {:id :h}))
+                    (state {:id :g}))
+                  (state {:id :f, :initial :f1}
+                    (state {:id :f1} (transition {:target :f2, :event :t1}))
+                    (state {:id :f2})))
+                (state {:id :k}))
+              (state {:id :l} (transition {:target :ha, :event :t3})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :i1) => true
+      (testing/in? env :j) => true
+      (testing/in? env :h) => true
+      (testing/in? env :g) => true
+      (testing/in? env :f1) => true
+      (testing/in? env :k) => true)
+    (testing/run-events! env :t1)
+    (assertions
+      (testing/in? env :i2) => true
+      (testing/in? env :j) => true
+      (testing/in? env :h) => true
+      (testing/in? env :g) => true
+      (testing/in? env :f2) => true
+      (testing/in? env :k) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :l) => true)
+    (testing/run-events! env :t3)
+    (assertions
+      (testing/in? env :i2) => true
+      (testing/in? env :j) => true
+      (testing/in? env :h) => true
+      (testing/in? env :g) => true
+      (testing/in? env :f2) => true
+      (testing/in? env :k) => true)))
+
+(specification
+  "history6"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (data-model
+                  {:expr {:x 2}})
+                (state {:id :a}
+                  (transition {:target :h, :event :t1}))
+                (state {:id :b, :initial :b1}
+                  (on-entry {}
+                    (assign {:location :x, :expr (fn [_ {:keys [x] :as env}] (* x 3))}))
+                  (history {:id :h} (transition {:target :b2}))
+                  (state {:id :b1})
+                  (state {:id :b2}
+                    (on-entry {}
+                      (assign {:location :x, :expr (fn [_ {:keys [x]}] (* x 5))}))
+                    (transition {:event :t2, :target :b3}))
+                  (state {:id :b3}
+                    (on-entry {}
+                      (assign {:location :x, :expr (fn [_ {:keys [x]}] (* x 7))}))
+                    (transition {:event :t3, :target :a}))
+                  (transition
+                    {:event :t4, :target :success, :cond (fn [_ {:keys [x]}] (= x 4410))})
+                  (transition
+                    {:event :t4, :target :really-fail, :cond (fn [_ {:keys [x]}] (= x 1470))})
+                  (transition {:event :t4, :target :fail}))
+                (state {:id :success})
+                (state {:id :fail})
+                (state {:id :really-fail}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b2) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b3) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :a) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :b3) => true)
+    (testing/run-events! env :t4)
+    (assertions (testing/in? env :success) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/internal_transitions_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/internal_transitions_spec.cljc
@@ -1,0 +1,87 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.internal-transitions-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script history log data-model]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(defn inc-x-expr [_ {:keys [x]}]
+  (inc x))
+
+(defn make-x-eq-expr [v]
+  (fn [_ {:keys [x]}] (= x v)))
+
+(specification "test0"
+  (let [chart (chart/statechart {}
+              (data-model
+                {:expr {:x 0}})
+              (state
+                {:id :a}
+                (on-entry {}
+                  (assign {:location :x, :expr inc-x-expr}))
+                (on-exit {}
+                  (assign {:location :x, :expr inc-x-expr}))
+                (state {:id :a1})
+                (state {:id :a2}
+                  (transition {:target :b, :event :t2, :cond (make-x-eq-expr 1) }))
+                (transition
+                  {:target :a2, :event :t1, :type :internal, :cond (make-x-eq-expr 1)}))
+              (state {:id :b}
+                (transition {:target :c, :event :t3, :cond (make-x-eq-expr 2)}))
+              (state {:id :c}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :a2) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :b) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :c) => true)))
+
+(specification
+  "test1"
+  (let [chart
+            (chart/statechart
+              {}
+              (data-model
+                {:expr {:x 0}})
+              (parallel
+                {:id :p}
+                (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                (on-exit {} (assign {:location :x, :expr inc-x-expr}))
+                (state
+                  {:id :a}
+                  (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                  (on-exit {} (assign {:location :x, :expr inc-x-expr}))
+                  (state {:id :a1}
+                    (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                    (on-exit {} (assign {:location :x, :expr inc-x-expr})))
+                  (state {:id :a2}
+                    (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                    (on-exit {} (assign {:location :x, :expr inc-x-expr}))
+                    (transition {:target :c, :event :t2, :cond (make-x-eq-expr 5)}))
+                  (transition
+                    {:target :a2, :event :t1, :type :internal, :cond (make-x-eq-expr 3)}))
+                (state {:id :b} (state {:id :b1}) (state {:id :b2})))
+              (state {:id :c}
+                (transition {:target :d, :event :t3, :cond (make-x-eq-expr 8)}))
+              (state {:id :d}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)
+    (testing/run-events! env :t1)
+    (assertions
+      (testing/in? env :a2) => true
+      (testing/in? env :b1) => true)
+    (testing/run-events! env :t2)
+    (assertions
+      (testing/in? env :c) => true)
+    (testing/run-events! env :t3)
+    (assertions
+      (testing/in? env :d) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/misc_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/misc_spec.cljc
@@ -1,0 +1,22 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.misc-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script history log]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification
+  "deep-initial"
+  (let [chart (chart/statechart
+                {:initial :s2}
+                (state {:id :uber}
+                  (state {:id :s1}
+                    (on-entry {})
+                    (transition {:event :ev1, :target :s2}))
+                  (state {:id :s2})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :s2) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/more_parallel_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/more_parallel_spec.cljc
@@ -1,0 +1,361 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.more-parallel-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script history log]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(defn inc-x-expr [_ {:keys [x]}]
+  (inc x))
+
+(defn make-x-eq-expr [v]
+  (fn [_ {:keys [x]}] (= x v)))
+
+(specification
+  "test0"
+  (let [chart (chart/statechart
+                {}
+                (parallel {:id :p}
+                  (state {:id :a} (transition {:target :a, :event :t}))
+                  (state {:id :b})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true (testing/in? env :b) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a) => true (testing/in? env :b) => true)))
+
+(specification
+  "test1"
+  (let [chart (chart/statechart
+                {}
+                (parallel {:id :p}
+                  (state {:id :a}
+                    (transition {:event :t, :target :a})
+                    (state {:id :a1})
+                    (state {:id :a2}))
+                  (state {:id :b} (state {:id :b1}) (state {:id :b2}))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true (testing/in? env :b1) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a1) => true (testing/in? env :b1) => true)))
+
+(specification
+  "test10"
+  (let [chart (chart/statechart
+                {}
+                (data-model
+                  {:expr {:x 0}})
+                (parallel
+                  {:id :p}
+                  (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                  (on-exit {} (assign {:location :x, :expr inc-x-expr}))
+                  (state {:id :a}
+                    (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                    (on-exit {} (assign {:location :x, :expr inc-x-expr}))
+                    (transition {:target :a, :event :t1, :cond (make-x-eq-expr 2)}))
+                  (state {:id :b})
+                  (transition {:target :c, :event :t2, :cond (make-x-eq-expr 6)}))
+                (state {:id :c}
+                  (transition {:target :d, :event :t3, :cond (make-x-eq-expr 8)}))
+                (state {:id :d}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a) => true
+      (testing/in? env :b) => true)
+
+    (testing/run-events! env :t1)
+    (assertions
+      (testing/in? env :a) => true
+      (testing/in? env :b) => true)
+
+    (testing/run-events! env :t2)
+    (assertions
+      (testing/in? env :a) => true
+      (testing/in? env :b) => true)
+
+    (testing/run-events! env :t3)
+    (assertions
+      (testing/in? env :a) => true
+      (testing/in? env :b) => true)))
+
+(specification
+  "test10b"
+  (let [chart (chart/statechart {}
+                (data-model {:expr {:x 0}})
+                (parallel
+                  {:id :p}
+                  (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                  (on-exit {} (assign {:location :x, :expr inc-x-expr}))
+                  (state {:id :a}
+                    (on-entry {} (assign {:location :x, :expr inc-x-expr}))
+                    (on-exit {} (assign {:location :x, :expr inc-x-expr}))
+                    (transition {:target :a, :event :t1, :cond (make-x-eq-expr 2)}))
+                  (state {:id :b})
+                  (transition {:target :c, :event :t2, :cond (make-x-eq-expr 4)}))
+                (state {:id :c}
+                  (transition {:target :d, :event :t3, :cond (make-x-eq-expr 6)}))
+                (state {:id :d}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true (testing/in? env :b) => true)
+    (testing/run-events! env :t1)
+    (assertions (testing/in? env :a) => true (testing/in? env :b) => true)
+    (testing/run-events! env :t2)
+    (assertions (testing/in? env :c) => true)
+    (testing/run-events! env :t3)
+    (assertions (testing/in? env :d) => true)))
+
+(specification
+  "test2" :focus
+  (let [chart (chart/statechart {}
+                (parallel
+                  {:id :p}
+                  (state {:id :a}
+                    (transition {:event :t, :target :a})
+                    (state {:id :a1})
+                    (state {:id :a2}))
+                  (state {:id :b}
+                    (state {:id :b1}
+                      (transition {:event :t, :target :b2}))
+                    (state {:id :b2}))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)
+
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)))
+
+(specification
+  "test2b"
+  (let [chart (chart/statechart {}
+                (parallel
+                  {:id :p}
+                  (state {:id :b}
+                    (state {:id :b1}
+                      (transition {:event :t, :target :b2}))
+                    (state {:id :b2}))
+                  (state {:id :a}
+                    (transition {:event :t, :target :a})
+                    (state {:id :a1})
+                    (state {:id :a2}))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)
+
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b2) => true)))
+
+(specification
+  "test3"
+  (let [chart (chart/statechart
+                {}
+                (parallel
+                  {:id :p}
+                  (state {:id :a}
+                    (transition {:event :t, :target :a2})
+                    (state {:id :a1})
+                    (state {:id :a2}))
+                  (state {:id :b}
+                    (state {:id :b1} (transition {:event :t, :target :b2}))
+                    (state {:id :b2}))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a2) => true
+      (testing/in? env :b1) => true)))
+
+(specification
+  "test3b"
+  (let [chart (chart/statechart
+                {}
+                (parallel
+                  {:id :p}
+                  (state {:id :b}
+                    (state {:id :b1} (transition {:event :t, :target :b2}))
+                    (state {:id :b2}))
+                  (state {:id :a}
+                    (transition {:event :t, :target :a2})
+                    (state {:id :a1})
+                    (state {:id :a2}))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b2) => true)))
+
+(specification
+  "test4"
+  (let [chart (chart/statechart
+                {}
+                (parallel {:id :p}
+                  (state {:id :a}
+                    (transition {:event :t, :target :a})
+                    (state {:id :a1})
+                    (state {:id :a2}))
+                  (state {:id :b}
+                    (transition {:event :t, :target :b})
+                    (state {:id :b1})
+                    (state {:id :b2}))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)))
+
+(specification
+  "test5"
+  (let [chart (chart/statechart
+                {}
+                (parallel {:id :p}
+                  (state {:id :a}
+                    (transition {:event :t, :target :a2})
+                    (state {:id :a1})
+                    (state {:id :a2}))
+                  (state {:id :b}
+                    (transition {:event :t, :target :b2})
+                    (state {:id :b1})
+                    (state {:id :b2}))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :a1) => true
+      (testing/in? env :b1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a2) => true
+      (testing/in? env :b1) => true)))
+
+(specification
+  "test6"
+  (let [chart
+            (chart/statechart
+              {}
+              (parallel
+                {:id :p}
+                (state {:id :a}
+                  (transition {:event :t, :target :a22})
+                  (state {:id :a1} (state {:id :a11}) (state {:id :a12}))
+                  (state {:id :a2} (state {:id :a21}) (state {:id :a22})))
+                (state {:id :b}
+                  (state {:id :b1}
+                    (state {:id :b11}
+                      (transition {:event :t, :target :b12}))
+                    (state {:id :b12}))
+                  (state {:id :b2} (state {:id :b21}) (state {:id :b22})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a11) => true (testing/in? env :b11) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a22) => true (testing/in? env :b11) => true)))
+
+(specification
+  "test6b"
+  (let [chart
+            (chart/statechart
+              {}
+              (parallel
+                {:id :p}
+                (state {:id :b}
+                  (state {:id :b1}
+                    (state {:id :b11}
+                      (transition {:event :t, :target :b12}))
+                    (state {:id :b12}))
+                  (state {:id :b2} (state {:id :b21}) (state {:id :b22})))
+                (state {:id :a}
+                  (transition {:event :t, :target :a22})
+                  (state {:id :a1} (state {:id :a11}) (state {:id :a12}))
+                  (state {:id :a2} (state {:id :a21}) (state {:id :a22})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a11) => true (testing/in? env :b11) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a11) => true (testing/in? env :b12) => true)))
+
+(specification
+  "test7"
+  (let [chart
+            (chart/statechart
+              {}
+              (parallel
+                {:id :p}
+                (state {:id :a}
+                  (transition {:event :t, :target :a22})
+                  (state {:id :a1} (state {:id :a11}) (state {:id :a12}))
+                  (state {:id :a2} (state {:id :a21}) (state {:id :a22})))
+                (state {:id :b}
+                  (transition {:event :t, :target :b22})
+                  (state {:id :b1} (state {:id :b11}) (state {:id :b12}))
+                  (state {:id :b2} (state {:id :b21}) (state {:id :b22})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a11) => true (testing/in? env :b11) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a22) => true (testing/in? env :b11) => true)))
+
+(specification
+  "test8"
+  (let [chart
+            (chart/statechart
+              {}
+              (state {:id :x} (transition {:event :t, :target :a22}))
+              (parallel
+                {:id :p}
+                (state {:id :a}
+                  (state {:id :a1} (state {:id :a11}) (state {:id :a12}))
+                  (state {:id :a2} (state {:id :a21}) (state {:id :a22})))
+                (state {:id :b}
+                  (state {:id :b1} (state {:id :b11}) (state {:id :b12}))
+                  (state {:id :b2} (state {:id :b21}) (state {:id :b22})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :x) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a22) => true (testing/in? env :b11) => true)))
+
+(specification
+  "test9"
+  (let [chart
+            (chart/statechart
+              {}
+              (state {:id :x} (transition {:event :t, :target [:a22 :b22]}))
+              (parallel
+                {:id :p}
+                (state {:id :a}
+                  (state {:id :a1} (state {:id :a11}) (state {:id :a12}))
+                  (state {:id :a2} (state {:id :a21}) (state {:id :a22})))
+                (state {:id :b}
+                  (state {:id :b1} (state {:id :b11}) (state {:id :b12}))
+                  (state {:id :b2} (state {:id :b21}) (state {:id :b22})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :x) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a22) => true (testing/in? env :b22) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/parallel_interrupt_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/parallel_interrupt_spec.cljc
@@ -1,0 +1,814 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.parallel-interrupt-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script history log]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification
+  "test0"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel {:id :b}
+                  (state {:id :c} (transition {:event :t, :target :a1}))
+                  (state {:id :d}
+                    (transition {:event :t, :target :a2})))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d) => true)
+  (testing/run-events! env :t)
+  (assertions
+    (testing/in? env :a1) => true)) )
+
+(specification
+  "test1"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel
+                {:id :b}
+                (state {:id :c, :initial :c1}
+                  (state {:id :c1} (transition {:event :t, :target :c2}))
+                  (state {:id :c2}))
+                (state {:id :d, :initial :d1}
+                  (state {:id :d1} (transition {:event :t, :target :a1}))))
+              (state {:id :a1}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d1) => true)))
+
+(specification
+  "test10"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a, :initial :b}
+                  (transition {:event :t, :target :c})
+                  (parallel {:id :b} (state {:id :b1}) (state {:id :b2}))
+                  (parallel {:id :c} (state {:id :c1}) (state {:id :c2}))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :b1) => true
+      (testing/in? env :b2) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :c2) => true)))
+
+(specification
+  "test11"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a, :initial :b}
+                  (parallel
+                    {:id :b}
+                    (state {:id :b1} (transition {:event :t, :target :d}))
+                    (state {:id :b2} (transition {:event :t, :target :c})))
+                  (parallel {:id :c} (state {:id :c1}) (state {:id :c2})))
+                (state {:id :d}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :b1) => true
+      (testing/in? env :b2) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :d) => true)))
+
+(specification
+  "test12"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a, :initial :b}
+                  (parallel
+                    {:id :b}
+                    (state {:id :b1} (transition {:event :t, :target :c}))
+                    (state {:id :b2} (transition {:event :t, :target :d})))
+                  (parallel {:id :c} (state {:id :c1}) (state {:id :c2})))
+                (state {:id :d}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :b1) => true
+      (testing/in? env :b2) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :c2) => true)))
+
+(specification
+  "test13"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a, :initial :b}
+                  (parallel {:id :b}
+                    (state {:id :b1}
+                      (transition {:event :t, :target :c}))
+                    (state {:id :b2})
+                    (transition {:event :t, :target :d}))
+                  (parallel {:id :c} (state {:id :c1}) (state {:id :c2})))
+                (state {:id :d}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :b1) => true
+      (testing/in? env :b2) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :c2) => true)))
+
+(specification
+  "test14"
+  (let [chart
+            (chart/statechart
+              {:initial :a}
+              (parallel
+                {:id :a}
+                (parallel
+                  {:id :b}
+                  (parallel
+                    {:id :c}
+                    (parallel {:id :d}
+                      (parallel {:id :e}
+                        (state {:id :i, :initial :i1}
+                          (state {:id :i1}
+                            (transition {:target :l,
+                                         :event :t}))
+                          (state {:id :i2}))
+                        (state {:id :j}))
+                      (state {:id :h}))
+                    (state {:id :g}))
+                  (state {:id :f, :initial :f1}
+                    (state {:id :f1} (transition {:target :f2, :event :t}))
+                    (state {:id :f2})))
+                (state {:id :k}))
+              (state {:id :l}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :i1) => true
+      (testing/in? env :j) => true
+      (testing/in? env :h) => true
+      (testing/in? env :g) => true
+      (testing/in? env :f1) => true
+      (testing/in? env :k) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :l) => true)))
+
+(specification
+  "test15"
+  (let [chart
+            (chart/statechart
+              {:initial :a}
+              (parallel
+                {:id :a}
+                (parallel
+                  {:id :b}
+                  (parallel
+                    {:id :c}
+                    (parallel {:id :d}
+                      (parallel {:id :e}
+                        (state {:id :i, :initial :i1}
+                          (state {:id :i1}
+                            (transition {:target :i2,
+                                         :event :t}))
+                          (state {:id :i2}))
+                        (state {:id :j}))
+                      (state {:id :h}))
+                    (state {:id :g}))
+                  (state {:id :f, :initial :f1}
+                    (state {:id :f1} (transition {:target :l, :event :t}))
+                    (state {:id :f2})))
+                (state {:id :k}))
+              (state {:id :l}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :i1) => true
+      (testing/in? env :j) => true
+      (testing/in? env :h) => true
+      (testing/in? env :g) => true
+      (testing/in? env :f1) => true
+      (testing/in? env :k) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :i2) => true
+      (testing/in? env :j) => true
+      (testing/in? env :h) => true
+      (testing/in? env :g) => true
+      (testing/in? env :f1) => true
+      (testing/in? env :k) => true)))
+
+(specification
+  "test16"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel {:id :b}
+                (state {:id :c} (transition {:event :t, :target :a}))
+                (state {:id :d} (transition {:event :t, :target :a2})))
+              (state {:id :a, :initial :a1} (state {:id :a1}) (state {:id :a2})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test17"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel {:id :b}
+                (state {:id :c} (transition {:event :t, :target :a2}))
+                (state {:id :d} (transition {:event :t, :target :a})))
+              (state {:id :a, :initial :a1} (state {:id :a1}) (state {:id :a2})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a2) => true)))
+
+(specification
+  "test18"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel {:id :b}
+                  (state {:id :c})
+                  (state {:id :d} (transition {:event :t, :target :a2}))
+                  (transition {:event :t, :target :a1}))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a2) => true)))
+
+(specification
+  "test19"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel
+                  {:id :b}
+                  (state {:id :c, :initial :c1}
+                    (state {:id :c1} (transition {:event :t, :target :c2}))
+                    (state {:id :c2}))
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1} (transition {:event :t, :target :d2}))
+                    (state {:id :d2}))
+                  (transition {:event :t, :target :a1}))
+                (state {:id :a1}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d2) => true)))
+
+(specification
+  "test2"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel
+                  {:id :b}
+                  (state {:id :c, :initial :c1}
+                    (state {:id :c1} (transition {:event :t, :target :a1}))
+                    (state {:id :c2}))
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1} (transition {:event :t, :target :d2}))
+                    (state {:id :d2})))
+                (state {:id :a1}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test20"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel {:id :b}
+                  (state {:id :c, :initial :c1}
+                    (state {:id :c1}
+                      (transition {:event :t, :target :c2}))
+                    (state {:id :c2}))
+                  (state {:id :d} (transition {:event :t, :target :a1}))
+                  (transition {:event :t, :target :a2}))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d) => true)))
+
+(specification
+  "test21"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel {:id :b}
+                  (state {:id :c} (transition {:event :t, :target :a1}))
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1}
+                      (transition {:event :t, :target :d2}))
+                    (state {:id :d2}))
+                  (transition {:event :t, :target :a2}))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test21b"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel {:id :b}
+                  (transition {:event :t, :target :a2})
+                  (state {:id :c} (transition {:event :t, :target :a1}))
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1}
+                      (transition {:event :t, :target :d2}))
+                    (state {:id :d2})))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test21c"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel
+                  {:id :b}
+                  (transition {:event :t, :target :a2})
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1} (transition {:event :t, :target :d2}))
+                    (state {:id :d2}))
+                  (state {:id :c} (transition {:event :t, :target :a1})))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d2) => true)))
+
+(specification
+  "test22"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel
+                  {:id :b}
+                  (state {:id :c, :initial :c1}
+                    (state {:id :c1} (transition {:event :t, :target :c2}))
+                    (state {:id :c2}))
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1} (transition {:event :t, :target :d2}))
+                    (state {:id :d2}))
+                  (transition {:event :t, :target :a1}))
+                (state {:id :a1}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d2) => true)))
+
+(specification
+  "test23"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel {:id :b}
+                  (state {:id :c})
+                  (state {:id :d} (transition {:event :t, :target :a2}))
+                  (transition {:event :t, :target :a1}))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a2) => true)))
+
+(specification
+  "test24"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel
+                  {:id :b}
+                  (state {:id :c, :initial :c1}
+                    (state {:id :c1} (transition {:event :t, :target :c2}))
+                    (state {:id :c2}))
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1} (transition {:event :t, :target :d2}))
+                    (state {:id :d2}))
+                  (transition {:event :t, :target :a1}))
+                (state {:id :a1}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d2) => true)))
+
+(specification
+  "test25"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel {:id :b}
+                  (state {:id :c, :initial :c1}
+                    (state {:id :c1}
+                      (transition {:event :t, :target :c2}))
+                    (state {:id :c2}))
+                  (state {:id :d} (transition {:event :t, :target :a1}))
+                  (transition {:event :t, :target :a2}))
+                (state {:id :a1})
+                (state {:id :a2}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d) => true)))
+
+(specification
+  "test27"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel
+                  {:id :b}
+                  (state {:id :c, :initial :c1}
+                    (state {:id :c1} (transition {:event :t, :target :c2}))
+                    (state {:id :c2}))
+                  (state {:id :d, :initial :d1}
+                    (state {:id :d1} (transition {:event :t, :target :d2}))
+                    (state {:id :d2}))
+                  (transition {:event :t, :target :a1}))
+                (state {:id :a1}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d2) => true)))
+
+(specification
+  "test28"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel {:id :b}
+                (state {:id :c})
+                (state {:id :d} (transition {:event :t, :target :a2}))
+                (transition {:event :t, :target :a}))
+              (state {:id :a, :initial :a1} (state {:id :a1}) (state {:id :a2})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a2) => true)))
+
+(specification
+  "test29"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel {:id :b}
+                (state {:id :c})
+                (state {:id :d} (transition {:event :t, :target :a}))
+                (transition {:event :t, :target :a2}))
+              (state {:id :a, :initial :a1} (state {:id :a1}) (state {:id :a2})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test3"
+  (let [chart (chart/statechart
+                {:initial :b}
+                (parallel
+                  {:id :b}
+                  (parallel
+                    {:id :c}
+                    (state {:id :e} (transition {:event :t, :target :a1}))
+                    (state {:id :f} (transition {:event :t, :target :a2}))
+                    (transition {:event :t, :target :a3}))
+                  (state {:id :d} (transition {:event :t, :target :a4})))
+                (state {:id :a1})
+                (state {:id :a2})
+                (state {:id :a3})
+                (state {:id :a4}))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :e) => true
+      (testing/in? env :f) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test30"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel {:id :b}
+                (state {:id :c, :initial :c1}
+                  (state {:id :c1}
+                    (transition {:event :t, :target :c2}))
+                  (state {:id :c2}))
+                (state {:id :d} (transition {:event :t, :target :a}))
+                (transition {:event :t, :target :a2}))
+              (state {:id :a, :initial :a1} (state {:id :a1}) (state {:id :a2})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c2) => true
+      (testing/in? env :d) => true)))
+
+(specification
+  "test31"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel
+                {:id :b}
+                (state {:id :c, :initial :c1}
+                  (state {:id :c1} (transition {:event :t, :target :a})))
+                (state {:id :d, :initial :d1}
+                  (state {:id :d1} (transition {:event :t, :target :d2}))
+                  (state {:id :d2}))
+                (transition {:event :t, :target :a2}))
+              (state {:id :a, :initial :a1} (state {:id :a1}) (state {:id :a2})))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :d1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test4"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel
+                {:id :b}
+                (parallel {:id :p}
+                  (state {:id :e} (transition {:event :t, :target :a1}))
+                  (state {:id :f} (transition {:event :t, :target :a2}))
+                  (transition {:event :t, :target :a3}))
+                (state {:id :d, :initial :g}
+                  (state {:id :g} (transition {:event :t, :target :h}))
+                  (state {:id :h})))
+              (state {:id :a1})
+              (state {:id :a2})
+              (state {:id :a3})
+              (state {:id :a4}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :e) => true
+      (testing/in? env :f) => true
+      (testing/in? env :g) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test5"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel
+                {:id :b}
+                (state {:id :d, :initial :g}
+                  (state {:id :g} (transition {:event :t, :target :h}))
+                  (state {:id :h}))
+                (parallel {:id :p}
+                  (state {:id :e} (transition {:event :t, :target :a1}))
+                  (state {:id :f} (transition {:event :t, :target :a2}))
+                  (transition {:event :t, :target :a3})))
+              (state {:id :a1})
+              (state {:id :a2})
+              (state {:id :a3})
+              (state {:id :a4}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :e) => true
+      (testing/in? env :f) => true
+      (testing/in? env :g) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :e) => true
+      (testing/in? env :f) => true
+      (testing/in? env :h) => true)))
+
+(specification
+  "test6"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel
+                {:id :b}
+                (state {:id :c, :initial :g}
+                  (state {:id :g} (transition {:event :t, :target :h}))
+                  (state {:id :h}))
+                (parallel
+                  {:id :d}
+                  (state {:id :e, :initial :e1}
+                    (state {:id :e1} (transition {:event :t, :target :e2}))
+                    (state {:id :e2}))
+                  (state {:id :f, :initial :f1}
+                    (state {:id :f1} (transition {:event :t, :target :f2}))
+                    (state {:id :f2})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :g) => true
+      (testing/in? env :e1) => true
+      (testing/in? env :f1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :h) => true
+      (testing/in? env :e2) => true
+      (testing/in? env :f2) => true)))
+
+(specification
+  "test7"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel
+                {:id :b}
+                (state {:id :c} (transition {:event :t, :target :a1}))
+                (parallel
+                  {:id :d}
+                  (state {:id :e, :initial :e1}
+                    (state {:id :e1} (transition {:event :t, :target :e2}))
+                    (state {:id :e2}))
+                  (state {:id :f, :initial :f1}
+                    (state {:id :f1} (transition {:event :t, :target :f2}))
+                    (state {:id :f2}))))
+              (state {:id :a1}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :e1) => true
+      (testing/in? env :f1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :a1) => true)))
+
+(specification
+  "test7b"
+  (let [chart
+            (chart/statechart
+              {:initial :b}
+              (parallel
+                {:id :b}
+                (parallel
+                  {:id :d}
+                  (state {:id :e, :initial :e1}
+                    (state {:id :e1} (transition {:event :t, :target :e2}))
+                    (state {:id :e2}))
+                  (state {:id :f, :initial :f1}
+                    (state {:id :f1} (transition {:event :t, :target :f2}))
+                    (state {:id :f2})))
+                (state {:id :c} (transition {:event :t, :target :a1})))
+              (state {:id :a1}))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :e1) => true
+      (testing/in? env :f1) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c) => true
+      (testing/in? env :e2) => true
+      (testing/in? env :f2) => true)))
+
+(specification
+  "test8"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a, :initial :b}
+                  (parallel {:id :b}
+                    (state {:id :b1})
+                    (state {:id :b2})
+                    (transition {:event :t, :target :c}))
+                  (parallel {:id :c} (state {:id :c1}) (state {:id :c2}))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :b1) => true
+      (testing/in? env :b2) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :c2) => true)))
+
+(specification
+  "test9"
+  (let [chart (chart/statechart
+                {:initial :a}
+                (state {:id :a, :initial :b}
+                  (parallel {:id :b}
+                    (state {:id :b1}
+                      (transition {:event :t, :target :c}))
+                    (state {:id :b2}))
+                  (parallel {:id :c} (state {:id :c1}) (state {:id :c2}))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :b1) => true
+      (testing/in? env :b2) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :c1) => true
+      (testing/in? env :c2) => true)))

--- a/src/test/com/fulcrologic/statecharts/algorithms/v20150901/parallel_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/algorithms/v20150901/parallel_spec.cljc
@@ -1,0 +1,111 @@
+(ns com.fulcrologic.statecharts.algorithms.v20150901.parallel-spec
+  (:require [com.fulcrologic.statecharts.elements :refer
+             [state initial parallel final transition raise on-entry on-exit
+              data-model assign script history log]]
+            [com.fulcrologic.statecharts :as sc]
+            [com.fulcrologic.statecharts.chart :as chart]
+            [com.fulcrologic.statecharts.testing :as testing]
+            [com.fulcrologic.statecharts.data-model.operations :as ops]
+            [fulcro-spec.core :refer [specification assertions =>]]))
+
+(specification
+  "test0"
+  (let [chart (chart/statechart
+                {}
+                (parallel {:id :p} (state {:id :a}) (state {:id :b})))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a) => true (testing/in? env :b) => true)))
+
+(specification
+  "test1"
+  (let [chart (chart/statechart
+                {}
+                (parallel
+                  {:id :p}
+                  (state {:id :a}
+                    (initial {} (transition {:target :a1}))
+                    (state {:id :a1} (transition {:event :t, :target :a2}))
+                    (state {:id :a2}))
+                  (state {:id :b}
+                    (initial {} (transition {:target :b1}))
+                    (state {:id :b1} (transition {:event :t, :target :b2}))
+                    (state {:id :b2}))))
+        env   (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions (testing/in? env :a1) => true (testing/in? env :b1) => true)
+    (testing/run-events! env :t)
+    (assertions (testing/in? env :a2) => true (testing/in? env :b2) => true)))
+
+(specification
+  "test2"
+  (let [chart
+            (chart/statechart
+              {}
+              (parallel
+                {:id :p1}
+                (state {:id :s1, :initial :p2}
+                  (parallel {:id :p2}
+                    (state {:id :s3})
+                    (state {:id :s4})
+                    (transition {:target :p3, :event :t}))
+                  (parallel {:id :p3} (state {:id :s5}) (state {:id :s6})))
+                (state
+                  {:id :s2, :initial :p4}
+                  (parallel {:id :p4}
+                    (state {:id :s7})
+                    (state {:id :s8})
+                    (transition {:target :p5, :event :t}))
+                  (parallel {:id :p5} (state {:id :s9}) (state {:id :s10})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :s3) => true
+      (testing/in? env :s4) => true
+      (testing/in? env :s7) => true
+      (testing/in? env :s8) => true)
+
+    (testing/run-events! env :t)
+
+    (assertions
+      (testing/in? env :s5) => true
+      (testing/in? env :s6) => true
+      (testing/in? env :s9) => true
+      (testing/in? env :s10) => true)))
+
+(specification
+  "test3"
+  (let [chart
+            (chart/statechart
+              {:initial :p1}
+              (parallel
+                {:id :p1}
+                (state
+                  {:id :s1, :initial :p2}
+                  (parallel {:id :p2}
+                    (state {:id :s3, :initial :s3.1}
+                      (state {:id :s3.1}
+                        (transition {:target :s3.2, :event :t}))
+                      (state {:id :s3.2}))
+                    (state {:id :s4}))
+                  (parallel {:id :p3} (state {:id :s5}) (state {:id :s6})))
+                (state
+                  {:id :s2, :initial :p4}
+                  (parallel {:id :p4}
+                    (state {:id :s7})
+                    (state {:id :s8})
+                    (transition {:target :p5, :event :t}))
+                  (parallel {:id :p5} (state {:id :s9}) (state {:id :s10})))))
+        env (testing/new-testing-env {:statechart chart} {})]
+    (testing/start! env)
+    (assertions
+      (testing/in? env :s3.1) => true
+      (testing/in? env :s4) => true
+      (testing/in? env :s7) => true
+      (testing/in? env :s8) => true)
+    (testing/run-events! env :t)
+    (assertions
+      (testing/in? env :s3.2) => true
+      (testing/in? env :s4) => true
+      (testing/in? env :s9) => true
+      (testing/in? env :s10) => true)))


### PR DESCRIPTION
First part of porting SCION tests (https://gitlab.com/scion-scxml/scion/-/tree/main/projects/libraries/test-framework/test) to statecharts. 

Tests files are named by SCION test folders and test names are named by test files to make it easy to compare with the original test code.

I've made some small changes to make them run, and some of the tests are failing right now. Mostly related to the parallel states, and when they should be exited on transition. 