### PR TITLE
Change `run-expression!` to return `nil` if expression failed to run

### DIFF
--- a/src/main/com/fulcrologic/statecharts/algorithms/v20150901_impl.cljc
+++ b/src/main/com/fulcrologic/statecharts/algorithms/v20150901_impl.cljc
@@ -88,7 +88,9 @@
         (sp/send! event-queue env {:event             :error.execution
                                    :send-id           session-id
                                    :data              {:error e}
-                                   :source-session-id session-id})))))
+                                   :source-session-id session-id})
+        ; Expression failed to run
+        nil))))
 
 (>defn condition-match
   [{::sc/keys [statechart] :as env} element-or-id]


### PR DESCRIPTION
- `condition-match` checks the result of `run-expression!`
- In case of expression failure, what was checked is the success of an `sp/send!`