### PR TITLE
BUGFIX: URL restoration ignored :route/segment on reachable targets

### DIFF
--- a/docs/ai/specs/TRACKER.md
+++ b/docs/ai/specs/TRACKER.md
@@ -1,6 +1,6 @@
 # Project Tracker
 
-<!-- Last updated: 2026-02-25 | Active: 0 | Blocked: 0 | Backlog: 0 | Done: 46 -->
+<!-- Last updated: 2026-03-29 | Active: 0 | Blocked: 0 | Backlog: 1 | Done: 46 -->
 
 ## Active
 
@@ -12,7 +12,9 @@
 
 ## Backlog
 
-(none)
+| Spec                          | Priority | Created    | Summary                                                                                      |
+|-------------------------------|----------|------------|----------------------------------------------------------------------------------------------|
+| reachable-segment-mismatch    | P1       | 2026-03-29 | `find-target-by-leaf-name-deep` ignores `:route/segment` on reachable (child chart) targets  |
 
 ## Done (recent)
 

--- a/docs/ai/specs/reachable-segment-mismatch.md
+++ b/docs/ai/specs/reachable-segment-mismatch.md
@@ -1,0 +1,89 @@
+# Spec: Reachable Target Lookup Ignores `:route/segment`
+
+**Status**: backlog
+**Priority**: P1
+**Created**: 2026-03-29
+**Owner**: conductor
+**GitHub**: #27
+
+## Context
+
+When a child chart route target uses `:route/segment` to customize its URL path segment,
+forward navigation (programmatic `route-to`) works correctly — the URL shows the custom
+segment (e.g. `/admin/main`). However, browser back/forward navigation to that URL fails
+silently because the URL restoration code cannot resolve the custom segment back to the
+correct target.
+
+This was reported in GitHub issue #27.
+
+## Root Cause
+
+`find-target-by-leaf-name-deep` in `url_history.cljc:66-86` has two lookup strategies:
+
+1. **Direct match** (line 79): calls `find-target-by-leaf-name`, which correctly uses
+   `element-segment` (respects `:route/segment` → falls back to `(name target)`).
+
+2. **Reachable match** (lines 82-85): searches `:route/reachable` sets on `istate` elements,
+   but matches using `(name kw)` — the keyword name of the reachable target, **not** its
+   `:route/segment` value.
+
+The reachable keywords (e.g. `::dashboard/Dashboard`) are references to elements in a
+*child* chart. The parent chart's `elements-by-id` doesn't contain those child elements,
+so `:route/segment` metadata isn't available at lookup time.
+
+Example: Child target `::dashboard/Dashboard` has `:route/segment "main"`. URL encodes as
+`/admin/main`. On restore, leaf-name is `"main"`, but `(name ::dashboard/Dashboard)` is
+`"Dashboard"` → no match → navigation fails.
+
+## Requirements
+
+1. URL restoration via browser back/forward must resolve custom `:route/segment` values
+   on reachable (child chart) targets, not just keyword names
+2. Forward navigation (route-to) behavior must remain unchanged
+3. Targets without `:route/segment` must continue to work via keyword name fallback
+4. No changes to URL encoding — only the decode/restore path is affected
+
+## Affected Files
+
+- `src/main/com/fulcrologic/statecharts/integration/fulcro/routing/url_history.cljc` — `find-target-by-leaf-name-deep`
+- `src/test/com/fulcrologic/statecharts/integration/fulcro/url_sync_headless_spec.cljc` — new test cases
+
+## Approach
+
+The reachable match branch needs access to the child chart's element metadata to check
+`:route/segment`. Two options:
+
+### Option A: Reverse segment index (preferred)
+
+Build a lookup map during `install-url-sync!` or chart registration that maps
+`segment-string → {:target-key kw :owner-id istate-id}` for all reachable targets across
+all registered charts. Pass this index to `find-target-by-leaf-name-deep` (or a new variant).
+
+**Pros**: Single O(1) lookup, clean separation
+**Cons**: Must be rebuilt when charts are registered/unregistered
+
+### Option B: Resolve child chart at lookup time
+
+When the direct match fails, iterate reachable sets and for each reachable keyword, look up
+the child chart's elements-by-id from the registry to check `element-segment`.
+
+**Pros**: Always current, no extra state
+**Cons**: Requires registry access in url_history.cljc, slower per-lookup
+
+### Option C: Store segment on reachable metadata
+
+Enhance `istate`/`rstate` to store a map in `:route/reachable` instead of a set, e.g.
+`{::dashboard/Dashboard {:route/segment "main"}}`. The reachable match branch can then
+check segment metadata directly.
+
+**Pros**: Self-contained, no external lookups
+**Cons**: Breaking change to `:route/reachable` format (set → map)
+
+## Verification
+
+1. [ ] Child chart target with `:route/segment "main"` generates URL `/parent/main`
+2. [ ] Browser back to `/parent/main` correctly resolves and navigates to that target
+3. [ ] Child chart target without `:route/segment` still works via keyword name
+4. [ ] Direct (same-chart) targets with `:route/segment` continue working
+5. [ ] Existing URL sync headless tests still pass
+6. [ ] New test: round-trip encode→decode for reachable targets with custom segments

--- a/src/main/com/fulcrologic/statecharts/integration/fulcro/routing.cljc
+++ b/src/main/com/fulcrologic/statecharts/integration/fulcro/routing.cljc
@@ -383,7 +383,10 @@
 
    * `:route/target` — The component registry key with a co-located statechart (or statechart-id).
    * `:route/segment` — (optional) Custom URL path segment string. Defaults to `(name target)`.
-   * `:route/reachable` — A set of route target keywords reachable through the child chart.
+   * `:route/reachable` — A set of route target keywords reachable through the child chart,
+     or a map of `{target-keyword \"segment\"}` when child targets use custom `:route/segment` values.
+     When a map is provided, the keys become the reachable set and the values are stored as
+     `:route/reachable-segments` for URL restoration.
    * `invoke-params` — A map merged into the invoke `params`.
    * `namelist`, `finalize`, `autoforward` — Same as `invoke` element options.
    * `on-done` — `(fn [env data & rest] ops)` run if the child chart hits a final state.
@@ -397,22 +400,54 @@
   (when (contains? state-props :id)
     (throw (ex-info "istate does not accept :id — the state ID is always derived from :route/target"
              {:route/target target :id id})))
-  (let [target-key  (coerce-to-keyword target)
-        id          target-key
-        reachable   (or reachable
-                      (let [cls (rc/registry-key->class target-key)]
-                        (when (nil? cls)
-                          (throw (ex-info (str "istate: component " target-key " is not registered. "
-                                           "Either require the component namespace or provide explicit :route/reachable.")
-                                   {:route/target target-key})))
-                        (let [child (rc/component-options cls sfro/statechart)]
-                          (when (nil? child)
-                            (throw (ex-info (str "istate: component " target-key " has no sfro/statechart option. "
-                                             "Either co-locate the chart on the component or provide explicit :route/reachable.")
-                                     {:route/target target-key})))
-                          (not-empty (reachable-targets child)))))
-        state-props (cond-> state-props
-                      reachable (assoc :route/reachable reachable))]
+  (let [target-key         (coerce-to-keyword target)
+        id                 target-key
+        ;; Normalize reachable: accept set (legacy) or map {kw "segment"} (new)
+        reachable-input    (or reachable
+                             (let [cls (rc/registry-key->class target-key)]
+                               (when (nil? cls)
+                                 (throw (ex-info (str "istate: component " target-key " is not registered. "
+                                                   "Either require the component namespace or provide explicit :route/reachable.")
+                                          {:route/target target-key})))
+                               (let [child-chart (rc/component-options cls sfro/statechart)]
+                                 (when (nil? child-chart)
+                                   (throw (ex-info (str "istate: component " target-key " has no sfro/statechart option. "
+                                                     "Either co-locate the chart on the component or provide explicit :route/reachable.")
+                                            {:route/target target-key})))
+                                 (not-empty (reachable-targets child-chart)))))
+        reachable-map?     (and reachable-input (map? reachable-input))
+        reachable          (cond
+                             (nil? reachable-input) nil
+                             reachable-map? (not-empty (set (keys reachable-input)))
+                             :else reachable-input)
+        ;; Build segment map: when user provides a map, values are segments.
+        ;; When auto-derived, walk child chart elements to extract :route/segment overrides.
+        reachable-segments (cond
+                             reachable-map?
+                             (not-empty (into {}
+                                         (map (fn [[kw seg]] [(coerce-to-keyword kw) seg]))
+                                         reachable-input))
+
+                             (and reachable (not reachable-input))
+                             nil
+
+                             reachable
+                             (let [cls         (rc/registry-key->class target-key)
+                                   child-chart (some-> cls (rc/component-options sfro/statechart))]
+                               (when child-chart
+                                 (not-empty
+                                   (into {}
+                                     (comp
+                                       (filter (fn [[_id el]]
+                                                 (and (:route/target el) (:route/segment el))))
+                                       (map (fn [[_id el]]
+                                              [(coerce-to-keyword (:route/target el)) (:route/segment el)])))
+                                     (::sc/elements-by-id child-chart)))))
+
+                             :else nil)
+        state-props        (cond-> state-props
+                             reachable (assoc :route/reachable reachable)
+                             reachable-segments (assoc :route/reachable-segments reachable-segments))]
     (apply state (-> (assoc state-props :id id :route/target target-key)
                    (dissoc :invoke-params :finalize :autoforward :namelist :on-done :exit-target :statechart-id))
       (on-exit {}

--- a/src/main/com/fulcrologic/statecharts/integration/fulcro/routing/url_history.cljc
+++ b/src/main/com/fulcrologic/statecharts/integration/fulcro/routing/url_history.cljc
@@ -67,22 +67,26 @@
   "Searches the parent chart's elements AND `:route/reachable` sets on istate elements.
    If a direct match is found in `elements-by-id` (via `element-segment`), returns
    `{:target-id id :child? false}`.
-   If the leaf-name matches a keyword in a `:route/reachable` set (by keyword name),
-   returns `{:target-key matched-keyword :child? true :owner-id istate-id}`.
-   Returns nil if not found.
+   If the leaf-name matches a keyword in a `:route/reachable` set, returns
+   `{:target-key matched-keyword :child? true :owner-id istate-id}`.
 
-   NOTE: Reachable matching uses `(name kw)`, not `:route/segment`. If a child chart
-   uses `:route/segment` on a reachable target, ensure the keyword name matches."
+   Reachable matching checks `:route/reachable-segments` first (a map of keyword to
+   custom segment string), then falls back to matching by `(name kw)`."
   [elements-by-id leaf-name]
   (or
     ;; Direct match in this chart (uses element-segment)
     (when-let [id (find-target-by-leaf-name elements-by-id leaf-name)]
       {:target-id id :child? false})
-    ;; Search reachable sets on istates (matches by keyword name)
+    ;; Search reachable targets on istates
     (some (fn [[id element]]
             (when-let [reachable (:route/reachable element)]
-              (when-let [matched (some (fn [kw] (when (= (name kw) leaf-name) kw)) reachable)]
-                {:target-key matched :child? true :owner-id id})))
+              (let [seg-map (:route/reachable-segments element)
+                    ;; Check segment map first, then fall back to keyword name
+                    matched (or (when seg-map
+                                  (some (fn [[kw seg]] (when (= seg leaf-name) kw)) seg-map))
+                              (some (fn [kw] (when (= (name kw) leaf-name) kw)) reachable))]
+                (when matched
+                  {:target-key matched :child? true :owner-id id}))))
       elements-by-id)))
 
 ;; ---------------------------------------------------------------------------

--- a/src/test/com/fulcrologic/statecharts/integration/fulcro/routing/url_sync_headless_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/integration/fulcro/routing/url_sync_headless_spec.cljc
@@ -748,6 +748,135 @@
            (cleanup))))))
 
 ;; ---------------------------------------------------------------------------
+;; Custom segments on reachable targets (Issue #27)
+;; ---------------------------------------------------------------------------
+
+(defsc DashMain [_ _]
+  {:query         [:page/id]
+   :ident         :page/id
+   :initial-state {:page/id :dash-main}})
+
+(defsc DashReports [_ _]
+  {:query         [:page/id]
+   :ident         :page/id
+   :initial-state {:page/id :dash-reports}})
+
+(def dash-main-key (comp/class->registry-key DashMain))
+(def dash-reports-key (comp/class->registry-key DashReports))
+
+;; Child chart with custom :route/segment values
+(def dash-child-chart
+  (chart/statechart {:initial :state/route-root}
+    (sroute/routing-regions
+      (sroute/routes {:id :region/dash-routes :routing/root `DashPanel :initial dash-main-key}
+        (sroute/rstate {:route/target `DashMain :route/segment "overview"})
+        (sroute/rstate {:route/target `DashReports :route/segment "reports"})))))
+
+(defsc DashPanel [_ _]
+  {:query                                                                      [:dash/id :ui/current-route]
+   :ident                                                                      (fn [] [:component/id ::dash-panel])
+   :initial-state                                                              {:dash/id :dash}
+   sfro/statechart dash-child-chart})
+
+(def dash-panel-key (comp/class->registry-key DashPanel))
+
+;; Parent chart using map form of :route/reachable to declare custom segments
+(def segment-cross-chart
+  (chart/statechart {:initial :state/route-root}
+    (sroute/routing-regions
+      (sroute/routes {:id :region/routes :routing/root `RootComp :initial page-a-key}
+        (sroute/rstate {:route/target `PageA})
+        (sroute/rstate {:route/target `PageB})
+        (sroute/istate {:route/target    `DashPanel
+                        :route/segment   "dash"
+                        :route/reachable {dash-main-key    "overview"
+                                          dash-reports-key "reports"}})))))
+
+#?(:clj
+   (specification "Reachable targets with custom :route/segment (Issue #27)"
+     (component "URL restoration resolves custom segment on reachable target"
+       (let [app      (test-app)
+             provider (rsh/simulated-url-history "/")]
+         (sroute/start! app segment-cross-chart)
+         (settle! app)
+         (let [cleanup (sroute/install-url-sync! app {:provider provider})]
+           (sroute/url-sync-on-save sid nil app)
+
+           ;; Navigate to DashMain (reachable through DashPanel istate)
+           (sroute/route-to! app `DashMain)
+           (settle! app)
+           (sroute/url-sync-on-save sid nil app)
+
+           (assertions
+             "URL uses custom segments for both parent and child"
+             (ruh/current-href provider) => "/dash/overview"
+             "active leaf is DashMain"
+             (sroute/active-leaf-routes app) => #{dash-main-key})
+
+           ;; Navigate within child: DashMain -> DashReports
+           (sroute/route-to! app `DashReports)
+           (settle! app)
+           (let [state-map        (rapp/current-state app)
+                 child-session-id (get-in state-map [::sc/local-data sid :invocation/id dash-panel-key])]
+             (when child-session-id
+               (sroute/url-sync-on-save child-session-id nil app)))
+
+           (assertions
+             "URL uses custom segment for child route"
+             (ruh/current-href provider) => "/dash/reports")
+           (cleanup))))
+
+     (component "browser back resolves custom segment on reachable target"
+       (let [app      (test-app)
+             provider (rsh/simulated-url-history "/")]
+         (sroute/start! app segment-cross-chart)
+         (settle! app)
+         (let [cleanup (sroute/install-url-sync! app {:provider provider})]
+           (sroute/url-sync-on-save sid nil app)
+
+           ;; Navigate: PageA -> DashMain -> DashReports -> PageB
+           (sroute/route-to! app `DashMain)
+           (settle! app)
+           (sroute/url-sync-on-save sid nil app)
+
+           (sroute/route-to! app `DashReports)
+           (settle! app)
+           (sroute/url-sync-on-save sid nil app)
+
+           (sroute/route-to! app `PageB)
+           (settle! app)
+           (sroute/url-sync-on-save sid nil app)
+
+           (assertions
+             "at PageB"
+             (sroute/active-leaf-routes app) => #{page-b-key})
+
+           ;; Back to DashReports — this is the bug scenario from issue #27
+           ;; URL will be /dash/reports, and "reports" must resolve via reachable-segments
+           (ruh/go-back! provider)
+           (settle! app)
+           (sroute/url-sync-on-save sid nil app)
+
+           (assertions
+             "back navigated to DashReports via custom segment"
+             (sroute/active-leaf-routes app) => #{dash-reports-key}
+             "URL is /dash/reports"
+             (ruh/current-href provider) => "/dash/reports")
+
+           ;; Back to DashMain
+           (ruh/go-back! provider)
+           (settle! app)
+           (sroute/url-sync-on-save sid nil app)
+
+           (assertions
+             "back navigated to DashMain via custom segment"
+             (sroute/active-leaf-routes app) => #{dash-main-key}
+             "URL is /dash/overview"
+             (ruh/current-href provider) => "/dash/overview")
+
+           (cleanup))))))
+
+;; ---------------------------------------------------------------------------
 ;; Slice 6: Child communication
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #27 — `find-target-by-leaf-name-deep` ignored `:route/segment` on reachable (child chart) targets during URL restoration.

- **Root cause**: Reachable matching used `(name kw)` (keyword name) instead of the custom `:route/segment` value. URL *encoding* correctly used custom segments, but *decoding* (browser back/forward) couldn't resolve them back.
- **Fix**: `istate` now accepts a **map form** for `:route/reachable` where values are segment strings: `{target-kw "segment"}`. Normalized to a set internally (zero changes to existing consumers), with segment mapping stored in new `:route/reachable-segments` key. `find-target-by-leaf-name-deep` checks segments first, falls back to keyword name.
- **Auto-derive**: When `istate` can introspect the child chart at definition time, `:route/reachable-segments` is also built automatically from child elements with `:route/segment`.
- **Backward compatible**: Existing set form for `:route/reachable` continues to work unchanged.

## Test plan

- [x] All 1413 existing assertions pass (297 tests)
- [x] New test: forward navigation with custom segments on reachable targets produces correct URLs (`/dash/overview`, `/dash/reports`)
- [x] New test: browser back resolves custom segment on reachable target (the exact bug scenario from #27)
- [x] Direct `find-target-by-leaf-name-deep` verification: segment match, keyword fallback, and no-match all correct

Generated with [Claude Code](https://claude.com/claude-code)
