### PR TITLE
Fix #33: reject double-slash URLs from empty :route/segment

### DIFF
--- a/Guide.adoc
+++ b/Guide.adoc
@@ -1274,6 +1274,58 @@ Segments compose from the routing root down to the active leaf:
 | `UserEdit` with `:route/segment "edit"` nested under `UserDetail` nested under `UserList` with `:route/segment "users"` | `/users/UserDetail/edit`
 |===
 
+==== Empty Segments — Initial-Leaf Marker
+
+There is one sanctioned use of `:route/segment ""`: marking the **initial-chain leaf** of a `routes` node so that the parent's URL alone enters the leaf. This is how you make `/admin` (rather than `/admin/dashboard`) display the admin dashboard, or how you make `/` enter a chart's default home leaf.
+
+The marker is intentionally narrow because "no URL contribution" is otherwise ambiguous: the URL→state mapping needs to round-trip, and a non-leaf or non-initial transparent state would make the URL unable to identify which state to enter.
+
+**Rules** (enforced at chart registration when `:routing/checks :strict`):
+
+* The state must be an `rstate` — never an `istate`. (An `istate` invokes a child chart, and its segment is the bridge that lets the URL descend into the child's URL space; without it, deep-URL traversal is impossible.)
+* The state must be a leaf — no descendant route states.
+* The state must be reached by walking `:initial` from its enclosing `routes` node down through any compound states' `:initial` declarations.
+
+**Composition with `rstate` only** — a chart whose default leaf wants to ride on the parent's URL:
+
+[source,clojure]
+-----
+(sroute/routes {:id :region/main :routing/root `ui/Root :initial :ns/Home}
+  ;; "/" enters Home (segment is empty, so only the parent contributes)
+  (sroute/rstate {:route/target :ns/Home :route/segment ""})
+  ;; "/settings" is unaffected — it's not the initial-chain leaf
+  (sroute/rstate {:route/target :ns/Settings :route/segment "settings"}))
+-----
+
+**Composition with `istate` invoking a child chart** — the parent `istate` always carries a real segment; the child chart's *initial* leaf can carry the marker so that the parent's segment alone is the URL:
+
+[source,clojure]
+-----
+;; Parent chart: istate `admin` invokes the admin child chart at /admin
+(sroute/routes {:id :region/main :routing/root `ui/Root}
+  (sroute/istate {:route/target `ui/AdminPanel
+                  :route/segment "admin"     ;; REQUIRED — bridge into child URL
+                  :route/reachable {::Dashboard ""
+                                    ::Users    "users"}}))
+
+;; Child chart: Dashboard is the initial leaf and rides on /admin
+(sroute/routes {:id :admin/routes :routing/root `ui/AdminPanel :initial ::Dashboard}
+  (sroute/rstate {:route/target ::Dashboard :route/segment ""})  ;; "/admin"
+  (sroute/rstate {:route/target ::Users     :route/segment "users"})) ;; "/admin/users"
+-----
+
+URL outcomes:
+
+[cols="2,3"]
+|===
+| Active leaf | URL
+
+| Child chart at `Dashboard` (initial-chain leaf, empty segment) | `/admin`
+| Child chart at `Users`                                         | `/admin/users`
+|===
+
+If you put `:route/segment ""` on the parent `istate`, registration fails with `:routing/invalid-empty-segment` — the parent must always contribute a real segment because it is the bridge into the child's URL.
+
 ==== Route Parameters
 
 In the default URL encoding route parameters are **not** encoded in URL path segments.
@@ -1983,6 +2035,7 @@ The validator detects:
 * **Duplicate segment chains** -- two leaf routes with identical full segment paths (e.g. both resolve to `/users/edit`).
 * **Reachable collisions** -- a `:route/reachable` target (whether auto-derived or explicit) whose simple name collides with a direct route target.
 * **Invalid routing root** -- a `routes` node with a nil or non-coercible `:routing/root`.
+* **Invalid empty segment** -- `:route/segment ""` placed somewhere other than the initial-chain leaf of a `routes` node, or placed on an `istate` (which must always carry a real segment so the URL can descend into the child chart). See <<Empty Segments — Initial-Leaf Marker>>.
 
 TIP: Use `:routing/checks :strict` during development to catch configuration problems as thrown exceptions rather than logged warnings.
 

--- a/src/main/com/fulcrologic/statecharts/integration/fulcro/routing.cljc
+++ b/src/main/com/fulcrologic/statecharts/integration/fulcro/routing.cljc
@@ -180,7 +180,7 @@
           :else
           (let [seg (ruc/element-segment element)]
             (recur (:parent element)
-              (if seg (cons seg segments) segments))))))))
+              (if (and seg (not= "" seg)) (cons seg segments) segments))))))))
 
 (defn validate-duplicate-segments
   "Checks for leaf route states whose full segment chains collide. Two states with
@@ -206,6 +206,99 @@
                               (mapv :id entries))})))
       by-chain)))
 
+(defn- has-invoke-child?
+  "True when the state element with `state-id` has an `:invoke` child in the normalized chart."
+  [elements-by-id state-id]
+  (boolean
+    (some (fn [child-id]
+            (= :invoke (:node-type (get elements-by-id child-id))))
+      (:children (get elements-by-id state-id)))))
+
+(defn- enclosing-routes-node-id
+  "Walks up from `state-id` through `:parent` links to find the nearest ancestor
+   whose element carries `:routing/root` (i.e. a `routes` node). Returns the
+   ancestor's id, or nil if none found."
+  [elements-by-id state-id]
+  (loop [id (:parent (get elements-by-id state-id))]
+    (let [el (get elements-by-id id)]
+      (cond
+        (nil? el)                       nil
+        (contains? el :routing/root)    id
+        :else                           (recur (:parent el))))))
+
+(defn- initial-chain-leaf
+  "Walks the initial chain from `start-id` (a compound state) by following the
+   `:initial` attribute of each compound state until landing on a leaf state.
+   Returns the leaf's id, or nil if the chain cannot be resolved."
+  [elements-by-id start-id]
+  (loop [id start-id seen #{}]
+    (cond
+      (nil? id) nil
+      (contains? seen id) nil
+      :else
+      (let [el      (get elements-by-id id)
+            initial (:initial el)
+            target  (cond
+                      (keyword? initial) initial
+                      (and (vector? initial) (= 1 (count initial))) (first initial)
+                      :else nil)]
+        (if target
+          (recur target (conj seen id))
+          id)))))
+
+(defn validate-empty-segments
+  "Checks each route state with `:route/segment \"\"` against the rules for the
+   sanctioned 'no URL contribution' marker:
+
+   * Cannot host a child-chart invocation (i.e. cannot be an `istate`).
+   * Cannot have descendants that are themselves route states.
+   * Must lie on the initial chain of its enclosing `routes` node — i.e. walking
+     `:initial` from the routes node down through compound states must arrive
+     at this state.
+
+   Returns a sequence of issue maps, empty when all empty-segment markers are valid."
+  [{::sc/keys [elements-by-id]}]
+  (let [empty-marked  (into []
+                        (comp
+                          (filter (fn [[_ el]]
+                                    (and (:route/target el) (= "" (:route/segment el)))))
+                          (map first))
+                        elements-by-id)
+        invalid-issue (fn [state-id reason]
+                        {:warning-key :routing/invalid-empty-segment
+                         :state-id    state-id
+                         :reason      reason
+                         :message     (str "State " state-id " has :route/segment \"\" but " reason
+                                       ". The empty-segment marker is only valid on a leaf rstate "
+                                       "that lies on the initial chain of its enclosing routes node.")})]
+    (into []
+      (keep
+        (fn [state-id]
+          (let [el          (get elements-by-id state-id)
+                routes-id   (enclosing-routes-node-id elements-by-id state-id)
+                chain-leaf  (when routes-id (initial-chain-leaf elements-by-id routes-id))
+                child-route? (some
+                               (fn [cid]
+                                 (and (not= cid state-id)
+                                   (:route/target (get elements-by-id cid))))
+                               (:children el))]
+            (cond
+              (has-invoke-child? elements-by-id state-id)
+              (invalid-issue state-id "it invokes a child chart (istate) — its segment is the bridge into the child's URL")
+
+              child-route?
+              (invalid-issue state-id "it has a routed descendant — only leaf routes may use the marker")
+
+              (nil? routes-id)
+              (invalid-issue state-id "it is not enclosed by a routes node (no ancestor with :routing/root)")
+
+              (not= chain-leaf state-id)
+              (invalid-issue state-id (str "it is not the initial-chain leaf of its routes node "
+                                        "(initial chain resolves to " (pr-str chain-leaf) ")"))
+
+              :else nil))))
+      empty-marked)))
+
 (defn validate-route-configuration
   "Runs all route configuration validators on `chart`. Reports issues according
    to `mode` (`:warn` or `:strict`). Returns the chart unchanged."
@@ -214,7 +307,8 @@
                  (validate-duplicate-leaf-names chart)
                  (validate-duplicate-segments chart)
                  (validate-reachable-collisions chart)
-                 (validate-routing-root chart))]
+                 (validate-routing-root chart)
+                 (validate-empty-segments chart))]
     (doseq [{:keys [warning-key message] :as issue} issues]
       (report-issue! mode warning-key message (dissoc issue :message :warning-key)))
     chart))

--- a/src/main/com/fulcrologic/statecharts/integration/fulcro/routing/url_codec.cljc
+++ b/src/main/com/fulcrologic/statecharts/integration/fulcro/routing/url_codec.cljc
@@ -76,7 +76,7 @@
               :else
               (let [seg (element-segment element)]
                 (recur (:parent element)
-                  (if seg
+                  (if (and seg (not= "" seg))
                     (cons seg segments)
                     segments))))))))))
 

--- a/src/main/com/fulcrologic/statecharts/integration/fulcro/routing/url_codec_transit.cljc
+++ b/src/main/com/fulcrologic/statecharts/integration/fulcro/routing/url_codec_transit.cljc
@@ -119,11 +119,16 @@
 (defrecord TransitBase64Codec [prefix]
   url-codec/URLCodec
   (encode-url [_this {:keys [segments params route-elements]}]
-    (let [seg-strs (mapv (fn [state-id]
-                           (let [element (get route-elements state-id)]
-                             (or (url-codec/element-segment element) (name state-id))))
+    (let [seg-strs (into []
+                     (comp
+                       (map (fn [state-id]
+                              (let [element (get route-elements state-id)]
+                                (or (url-codec/element-segment element) (name state-id)))))
+                       (remove #{""}))
                      segments)
-          path     (str "/" (str/join "/" seg-strs))
+          path     (if (seq seg-strs)
+                     (str "/" (str/join "/" seg-strs))
+                     "/")
           raw-b64  (encode-params-base64 params)
           encoded  (when raw-b64
                      #?(:cljs (js/encodeURIComponent raw-b64)

--- a/src/test/com/fulcrologic/statecharts/integration/fulcro/routing/simulated_history_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/integration/fulcro/routing/simulated_history_spec.cljc
@@ -404,6 +404,29 @@
         "returns nil when no route element matches the leaf segment"
         decoded => nil)))
 
+  (component "empty :route/segment is dropped from the path"
+    (let [codec          (ruct/transit-base64-codec)
+          route-elements {:parent {:route/target 'com.example/Admin :route/segment "admin"}
+                          :leaf   {:route/target 'com.example/Home :route/segment ""}}
+          context        {:segments       [:parent :leaf]
+                          :params         nil
+                          :route-elements route-elements}
+          url            (ruc/encode-url codec context)]
+      (assertions
+        "ancestor segment alone forms the URL with no trailing slash"
+        url => "/admin")))
+
+  (component "all-empty segment chain encodes to root"
+    (let [codec          (ruct/transit-base64-codec)
+          route-elements {:leaf {:route/target 'com.example/Home :route/segment ""}}
+          context        {:segments       [:leaf]
+                          :params         nil
+                          :route-elements route-elements}
+          url            (ruc/encode-url codec context)]
+      (assertions
+        "produces / and not //"
+        url => "/")))
+
   (component "single segment route"
     (let [codec          (ruct/transit-base64-codec)
           route-elements {:dashboard {:route/target 'com.example/Dashboard}}

--- a/src/test/com/fulcrologic/statecharts/integration/fulcro/routing/url_codec_test.cljc
+++ b/src/test/com/fulcrologic/statecharts/integration/fulcro/routing/url_codec_test.cljc
@@ -63,6 +63,24 @@
       "returns nil for no match"
       (ruh/find-target-by-leaf-name elements "nope") => nil)))
 
+;; ---------------------------------------------------------------------------
+;; Empty :route/segment — sanctioned "initial-leaf rides on ancestor URL" marker
+;; ---------------------------------------------------------------------------
+
+(specification "path-from-configuration with :route/segment \"\""
+  (let [elements {:root {:id :root :children [:a]}
+                  :a    {:id :a :parent :root :route/target :ns/Dashboard :route/segment ""}}]
+    (assertions
+      "drops the empty segment, producing the chart-root URL with no trailing slash"
+      (ruc/path-from-configuration elements #{:root :a}) => "/"))
+
+  (let [elements {:root   {:id :root :children [:parent]}
+                  :parent {:id :parent :parent :root :route/target :ns/Admin :route/segment "admin" :children [:leaf]}
+                  :leaf   {:id :leaf :parent :parent :route/target :ns/Home :route/segment ""}}]
+    (assertions
+      "ancestor segment alone forms the URL when the leaf segment is empty"
+      (ruc/path-from-configuration elements #{:root :parent :leaf}) => "/admin")))
+
 (specification "current-url-path (cross-platform)"
   (assertions
     "extracts path segments from an absolute URL"

--- a/src/test/com/fulcrologic/statecharts/integration/fulcro/routing_test.cljc
+++ b/src/test/com/fulcrologic/statecharts/integration/fulcro/routing_test.cljc
@@ -276,6 +276,96 @@
         "Throws ex-info"
         (sroute/validate-route-configuration chart :strict) =throws=> #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)))))
 
+(specification "validate-empty-segments — rejection messages"
+  (component "Issue message names the state and the rule"
+    (let [chart  (chart/statechart {}
+                   (sroute/routes {:id :region/routes :routing/root `Foo :initial :ns/Other}
+                     (sroute/rstate {:route/target :ns/Home :route/segment ""})
+                     (sroute/rstate {:route/target :ns/Other :route/segment "other"})))
+          {:keys [message state-id reason]} (first (sroute/validate-empty-segments chart))]
+      (assertions
+        "names the offending state in the message"
+        (boolean (re-find #":ns/Home" message)) => true
+        "explains it must be on the initial chain"
+        (boolean (re-find #"initial chain" message)) => true
+        "carries the state-id in the issue map"
+        state-id => :ns/Home
+        "carries a non-empty reason string"
+        (boolean (seq reason)) => true)))
+
+  (component "Strict mode error message includes the rule explanation"
+    (let [chart (chart/statechart {}
+                  (sroute/routes {:id :region/routes :routing/root `Foo :initial :ns/Admin}
+                    (sroute/istate {:route/target :ns/Admin :route/segment ""
+                                    :route/reachable {:ns/AdminHome "home"}})))
+          ex    (try
+                  (sroute/validate-route-configuration chart :strict)
+                  nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e))]
+      (assertions
+        "throws an ex-info"
+        (some? ex) => true
+        "exception message names the offending state"
+        (boolean (re-find #":ns/Admin" (ex-message ex))) => true
+        "exception payload identifies it as :routing/invalid-empty-segment"
+        (:warning-key (ex-data ex)) => :routing/invalid-empty-segment)))
+
+  (component "Warn mode does not throw when an empty segment is invalid"
+    (let [chart (chart/statechart {}
+                  (sroute/routes {:id :region/routes :routing/root `Foo :initial :ns/Other}
+                    (sroute/rstate {:route/target :ns/Home :route/segment ""})
+                    (sroute/rstate {:route/target :ns/Other :route/segment "other"})))]
+      (assertions
+        "Returns the chart unchanged"
+        (sroute/validate-route-configuration chart :warn) => chart))))
+
+(specification "validate-empty-segments"
+  (component "An rstate that is the routes node's initial leaf may carry an empty segment"
+    (let [chart (chart/statechart {}
+                  (sroute/routes {:id :region/routes :routing/root `Foo :initial :ns/Home}
+                    (sroute/rstate {:route/target :ns/Home :route/segment ""})
+                    (sroute/rstate {:route/target :ns/Other :route/segment "other"})))]
+      (assertions
+        "Returns empty"
+        (sroute/validate-empty-segments chart) => [])))
+
+  (component "An rstate that is NOT on the initial chain rejects empty segment"
+    (let [chart (chart/statechart {}
+                  (sroute/routes {:id :region/routes :routing/root `Foo :initial :ns/Other}
+                    (sroute/rstate {:route/target :ns/Home :route/segment ""})
+                    (sroute/rstate {:route/target :ns/Other :route/segment "other"})))
+          issues (sroute/validate-empty-segments chart)]
+      (assertions
+        "Returns one issue"
+        (count issues) => 1
+        "Issue has the correct warning key"
+        (:warning-key (first issues)) => :routing/invalid-empty-segment
+        "Issue names the offending state"
+        (:state-id (first issues)) => :ns/Home)))
+
+  (component "An istate (child-chart host) cannot carry an empty segment"
+    (let [chart (chart/statechart {}
+                  (sroute/routes {:id :region/routes :routing/root `Foo :initial :ns/Admin}
+                    (sroute/istate {:route/target :ns/Admin :route/segment ""
+                                    :route/reachable {:ns/AdminHome "home"}})))
+          issues (sroute/validate-empty-segments chart)]
+      (assertions
+        "Returns one issue"
+        (count issues) => 1
+        "Issue has the correct warning key"
+        (:warning-key (first issues)) => :routing/invalid-empty-segment
+        "Issue names the offending state"
+        (:state-id (first issues)) => :ns/Admin)))
+
+  (component "Strict mode throws on invalid empty segment"
+    (let [chart (chart/statechart {}
+                  (sroute/routes {:id :region/routes :routing/root `Foo :initial :ns/Other}
+                    (sroute/rstate {:route/target :ns/Home :route/segment ""})
+                    (sroute/rstate {:route/target :ns/Other :route/segment "other"})))]
+      (assertions
+        "Throws ex-info"
+        (sroute/validate-route-configuration chart :strict) =throws=> #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)))))
+
 ;; ---------------------------------------------------------------------------
 ;; Slice 1: Pure utility functions
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #33.

## Summary
- URL encoders now drop empty `:route/segment` values instead of producing `//` paths that `pushState` rejects with SecurityError.
- New `validate-empty-segments` check (run by `validate-route-configuration`, which `start!` and `install-url-sync!` already invoke at registration) rejects `:route/segment ""` outside its sanctioned use:
  - cannot live on an `istate` (parent's segment is the bridge into the child chart's URL),
  - cannot have routed descendants,
  - must be the initial-chain leaf of its enclosing `routes` node.
- New Guide section "Empty Segments — Initial-Leaf Marker" documents the pattern with explicit `rstate`-only and `istate` + child-chart compositions.

## Why this shape
The reporter's repro produces `//` because two routed levels (parent `istate` proxy + child `rstate` leaf) both contributed empty segments. Allowing arbitrary empty segments would break URL↔state round-trip (decode lands on `:initial` and can't disambiguate multiple transparent leaves), so the marker is restricted to the one place where the round-trip is unambiguous: the initial-chain leaf of a `routes` node. That covers the legitimate case (a chart's home leaf showing at the parent's URL — e.g. `/admin` rendering the admin Dashboard) without making the URL ambiguous.

## Test plan
- [x] `path-from-configuration` drops empty segments (root-only and ancestor + empty leaf).
- [x] `TransitBase64Codec encode-url` drops empty segments and produces `/` (not `//`) for an all-empty chain; no trailing slash for ancestor-only.
- [x] `validate-empty-segments` accepts the initial-chain leaf, rejects non-initial leaves, rejects `istate` markers.
- [x] Issue map and ex-info contain the offending state id and the rule explanation; warn mode does not throw.
- [x] Full kaocha suite: 301 tests / 1433 assertions, 0 failures.
