### PR TITLE
fix bug preventing use of :finalize attribute of :invoke nodes

### DIFF
--- a/src/main/com/fulcrologic/statecharts/elements.cljc
+++ b/src/main/com/fulcrologic/statecharts/elements.cljc
@@ -547,5 +547,4 @@
     (new-element :invoke (cond-> (dissoc attrs :finalize)
                            id (assoc :explicit-id? true))
       (cond-> (vec children)
-        fattr (conj children (finalize {}
-                               (script {:expr fattr})))))))
+        fattr (conj (finalize {} (script {:expr fattr})))))))

--- a/src/test/com/fulcrologic/statecharts/elements_spec.cljc
+++ b/src/test/com/fulcrologic/statecharts/elements_spec.cljc
@@ -1,0 +1,24 @@
+(ns com.fulcrologic.statecharts.elements-spec
+  (:require
+   [com.fulcrologic.statecharts.elements :as e]
+   [fulcro-spec.core :refer [=> assertions component specification behavior]]))
+
+(specification "element construction"
+  (behavior "allows constructing 'invoke' elements with :finalize attribute"
+    (let [result (e/invoke {:id      :with-finalize
+                            :type    :future
+                            :src     (fn [{:keys [db data]}])
+                            :finalize (fn [env data])})]
+      (assertions
+        "produces an :invoke node"
+        (:node-type result) => :invoke
+        "has exactly one child (the :finalize node)"
+        (count (:children result)) => 1
+        "the child is a :finalize element"
+        (-> result :children first :node-type) => :finalize
+        "the :finalize element wraps a :script"
+        (-> result :children first :children first :node-type) => :script))))
+
+(comment
+  (require '[kaocha.repl :as k])
+  (k/run (-> *ns* str symbol)))


### PR DESCRIPTION
I was unable to construct invoke nodes with :finalize because the `cond->` form in `com.fulcrologic.statecharts.elements/invoke` was repeating `children` inside `conj`.